### PR TITLE
enabling pylint for examples and run examples in CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -22,6 +22,7 @@ jobs:
         run: pip install pylint==2.12.2
       - run: pip install .
       - run: pylint -j2 ./puma
+      - run: pylint -j2 ./examples/*.py
   darglint:
     runs-on: ubuntu-latest
     container: python:3.8-slim

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,10 +14,28 @@ jobs:
       - run: pip install .
       - run: pip install pytest
       - run: pytest -v puma/tests/
+  example_tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    container: python:3.8-slim
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - run: pip install .
+      - run: mkdir plots
+      - run: cd plots
+      - run: ls ../examples/*.py|xargs -n 1 -P 3 python
+      - uses: actions/upload-artifact@v3
+        with:
+          name: plot-example-artifacts
+          path: plots/*.png
   publish:
     name: Publish to PyPI
     # For now this is an independent job, but we should make this dependent on the
-    # unit tests --> put at end of test pipeline and make it require all the previous 
+    # unit tests --> put at end of test pipeline and make it require all the previous
     # jobs
     # needs: [linter, pylint, darglint, black]
     needs: [unit_tests]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,7 +27,7 @@ jobs:
       - run: pip install .
       - run: mkdir plots
       - run: cd plots
-      - run: ls ../examples/*.py|xargs -n 1 -P 3 python
+      - run: ls ../examples/*.py | xargs -n 1 -P 3 python
       - uses: actions/upload-artifact@v3
         with:
           name: plot-example-artifacts

--- a/examples/plot_basic_histogram.py
+++ b/examples/plot_basic_histogram.py
@@ -1,4 +1,4 @@
-"""Example of histogram plot that deviates from puma default plots"""
+"""Example of histogram plot that deviates from puma default plots."""
 
 import numpy as np
 

--- a/examples/plot_flavour_probabilities.py
+++ b/examples/plot_flavour_probabilities.py
@@ -1,4 +1,4 @@
-""" Example plot script for flavour probability comparison """
+"""Example plot script for flavour probability comparison."""
 
 from puma import histogram, histogram_plot
 from puma.utils import get_dummy_2_taggers

--- a/examples/plot_pie.py
+++ b/examples/plot_pie.py
@@ -1,3 +1,4 @@
+"""Example of pie char plot."""
 from puma import histogram, histogram_plot
 from puma.utils import get_dummy_2_taggers
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Running pylint now also for `./examples` folder
* Running now also examples in actions


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
