### PR TITLE
Stop ignoring "logging-fstring-interpolation" in pylint

### DIFF
--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -313,7 +313,7 @@ class histogram_plot(PlotBase):
                     "the bin edges. The range will be ignored."
                 )
         elif isinstance(self.bins, int):
-            logger.debug("Calculating bin edges of %s equal-width bins", self.bins)
+            logger.debug("Calculating bin edges of %i equal-width bins", self.bins)
             _, self.bins = np.histogram(
                 np.hstack([elem.values for elem in self.plot_objects.values()]),
                 bins=self.bins,
@@ -422,7 +422,7 @@ class histogram_plot(PlotBase):
                     "the bin edges. The range will be ignored."
                 )
         elif isinstance(self.bins, int):
-            logger.debug("Calculating bin edges of %s equal-width bins", self.bins)
+            logger.debug("Calculating bin edges of %i equal-width bins", self.bins)
             _, self.bins = np.histogram(
                 np.hstack([elem.values for elem in self.plot_objects.values()]),
                 bins=self.bins,

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -74,13 +74,13 @@ class histogram(PlotLineObject):
         # If flavour was specified, extract configuration from global config
         if self.flavour is not None:
             self.colour = global_config["flavour_categories"][self.flavour]["colour"]
-            logger.debug(f"Histogram colour was set to {self.colour}")
+            logger.debug("Histogram colour was set to %s", self.colour)
 
             self.label = (
                 f"{global_config['flavour_categories'][self.flavour]['legend_label']}"
                 f" {self.label_addition}"
             )
-            logger.debug(f"Histogram label was set to {self.label}")
+            logger.debug("Histogram label was set to %s", {self.label})
 
     def divide(self, other):
         """Calculate ratio between two class objects.
@@ -241,7 +241,7 @@ class histogram_plot(PlotBase):
 
         # Add key to histogram object
         curve.key = key
-        logger.debug(f"Adding histogram {key}")
+        logger.debug("Adding histogram %s", key)
 
         # Set linestyle
         if curve.linestyle is None:
@@ -271,13 +271,15 @@ class histogram_plot(PlotBase):
         """
         if self.reference_object is None:
             self.reference_object = [key]
-            logger.info(f"Using '{key}' as reference histogram")
+            logger.info("Using '%s' as reference histogram", key)
         else:
             self.reference_object.append(key)
             logger.warning(
-                f"You specified another curve {key} as reference for ratio. "
+                "You specified another curve %s as reference for ratio. "
                 "Adding it to reference histograms. "
-                f"New list of reference histograms: {self.reference_object}"
+                "New list of reference histograms: %s",
+                key,
+                self.reference_object,
             )
 
     def plot(self, **kwargs):
@@ -311,7 +313,7 @@ class histogram_plot(PlotBase):
                     "the bin edges. The range will be ignored."
                 )
         elif isinstance(self.bins, int):
-            logger.debug(f"Calculating bin edges of {self.bins} equal-width bins")
+            logger.debug("Calculating bin edges of %s equal-width bins", self.bins)
             _, self.bins = np.histogram(
                 np.hstack([elem.values for elem in self.plot_objects.values()]),
                 bins=self.bins,
@@ -420,7 +422,7 @@ class histogram_plot(PlotBase):
                     "the bin edges. The range will be ignored."
                 )
         elif isinstance(self.bins, int):
-            logger.debug(f"Calculating bin edges of {self.bins} equal-width bins")
+            logger.debug("Calculating bin edges of %s equal-width bins", self.bins)
             _, self.bins = np.histogram(
                 np.hstack([elem.values for elem in self.plot_objects.values()]),
                 bins=self.bins,
@@ -577,7 +579,7 @@ class histogram_plot(PlotBase):
             raise ValueError("Found more than one matching reference candidate.")
 
         logger.debug(
-            f"Reference histogram for '{histo.key}' is '{reference_histo.key}'"
+            "Reference histogram for '%s' is '%s'", histo.key, reference_histo.key
         )
 
         return reference_histo

--- a/puma/metrics.py
+++ b/puma/metrics.py
@@ -136,7 +136,7 @@ def eff_err(
     """
     logger.debug("Calculating efficiency error.")
     logger.debug("arr: %s", arr)
-    logger.debug("n_counts: %s", n_counts)
+    logger.debug("n_counts: %i", n_counts)
     logger.debug("suppress_zero_divison_error: %s", suppress_zero_divison_error)
     logger.debug("norm: %s", norm)
     # TODO: suppress_zero_divison_error should not be necessary, but functions calling
@@ -184,7 +184,7 @@ def rej_err(
     """
     logger.debug("Calculating rejection error.")
     logger.debug("arr: %s", arr)
-    logger.debug("n_counts: %s", n_counts)
+    logger.debug("n_counts: %i", n_counts)
     logger.debug("norm: %s", norm)
     if np.any(n_counts <= 0):
         raise ValueError(

--- a/puma/metrics.py
+++ b/puma/metrics.py
@@ -135,10 +135,10 @@ def eff_err(
     https://inspirehep.net/files/57287ac8e45a976ab423f3dd456af694
     """
     logger.debug("Calculating efficiency error.")
-    logger.debug(f"arr: {arr}")
-    logger.debug(f"n_counts: {n_counts}")
-    logger.debug(f"suppress_zero_divison_error: {suppress_zero_divison_error}")
-    logger.debug(f"norm: {norm}")
+    logger.debug("arr: %s", arr)
+    logger.debug("n_counts: %s", n_counts)
+    logger.debug("suppress_zero_divison_error: %s", suppress_zero_divison_error)
+    logger.debug("norm: %s", norm)
     # TODO: suppress_zero_divison_error should not be necessary, but functions calling
     # eff_err seem to need this functionality - should be deprecated though.
     if np.any(n_counts <= 0) and not suppress_zero_divison_error:
@@ -183,9 +183,9 @@ def rej_err(
     special case of `eff_err()`
     """
     logger.debug("Calculating rejection error.")
-    logger.debug(f"arr: {arr}")
-    logger.debug(f"n_counts: {n_counts}")
-    logger.debug(f"norm: {norm}")
+    logger.debug("arr: %s", arr)
+    logger.debug("n_counts: %s", n_counts)
+    logger.debug("norm: %s", norm)
     if np.any(n_counts <= 0):
         raise ValueError(
             f"You passed as argument `n_counts` {n_counts} but it has to be larger 0."

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -267,7 +267,7 @@ class PlotBase(PlotObject):
             # split figure vertically instead of horizonally
             if self.n_ratio_panels <= 1:
                 logger.warning(
-                    "You set the number of ratio panels to %s"
+                    "You set the number of ratio panels to %i"
                     "but also set the vertical splitting to True. Therefore no ratio"
                     "panels are created.",
                     self.n_ratio_panels,

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -267,9 +267,10 @@ class PlotBase(PlotObject):
             # split figure vertically instead of horizonally
             if self.n_ratio_panels <= 1:
                 logger.warning(
-                    f"You set the number of ratio panels to {self.n_ratio_panels}"
+                    "You set the number of ratio panels to %s"
                     "but also set the vertical splitting to True. Therefore no ratio"
-                    "panels are created."
+                    "panels are created.",
+                    self.n_ratio_panels,
                 )
             self.fig = Figure(figsize=(8, 6) if self.figsize is None else self.figsize)
             gs = gridspec.GridSpec(1, 11, figure=self.fig)
@@ -562,7 +563,7 @@ class PlotBase(PlotObject):
         **kwargs : kwargs
             kwargs passed to `matplotlib.figure.Figure.savefig()`
         """
-        logger.debug(f"Saving plot to {plot_name}")
+        logger.debug("Saving plot to %s", plot_name)
         self.fig.savefig(
             plot_name,
             transparent=transparent,

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -249,7 +249,8 @@ class roc_plot(PlotBase):
         ):
             logger.warning(
                 "You specified a different linestyle for the same rejection class "
-                f"{roc_curve.rej_class}. Will keep the linestyle defined first."
+                "%s. Will keep the linestyle defined first.",
+                roc_curve.rej_class,
             )
         if roc_curve.linestyle is None:
             roc_curve.linestyle = self.rej_class_ls[roc_curve.rej_class]
@@ -267,14 +268,17 @@ class roc_plot(PlotBase):
         ):
             logger.warning(
                 "You specified a different colour for the same label"
-                f" {roc_curve.label}. This will lead to a mismatch in the line colours"
-                " and the legend."
+                " %s. This will lead to a mismatch in the line colours"
+                " and the legend.",
+                roc_curve.label,
             )
         if roc_curve.colour is None:
             roc_curve.colour = self.label_colours[roc_curve.label]
 
         if reference:
-            logger.debug(f"Setting roc {key} as reference for {roc_curve.rej_class}.")
+            logger.debug(
+                "Setting roc %s as reference for %s.", key, roc_curve.rej_class
+            )
             self.set_roc_reference(key, roc_curve.rej_class)
 
     def set_roc_reference(self, key: str, rej_class: str):
@@ -303,8 +307,10 @@ class roc_plot(PlotBase):
             self.reference_roc[rej_class] = key
         else:
             logger.warning(
-                f"You specified a second roc curve {key} as reference for ratio. "
-                f"Using it as new reference instead of {self.reference_roc[rej_class]}."
+                "You specified a second roc curve %s as reference for ratio. "
+                "Using it as new reference instead of %s.",
+                key,
+                self.reference_roc[rej_class],
             )
             self.reference_roc[rej_class] = key
 

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -157,7 +157,7 @@ class var_vs_eff(PlotLineObject):
         self.x_bin_centres = (self.bin_edges[:-1] + self.bin_edges[1:]) / 2.0
         self.bin_widths = (self.bin_edges[1:] - self.bin_edges[:-1]) / 2.0
         self.n_bins = self.bin_edges.size - 1
-        logger.debug("N bins: %s", self.n_bins)
+        logger.debug("N bins: %i", self.n_bins)
 
     def _apply_binning(self):
         """Get binned distributions for the signal and background."""
@@ -202,7 +202,7 @@ class var_vs_eff(PlotLineObject):
             self.disc_cut = [
                 np.percentile(self.disc_sig, (1 - self.wp) * 100)
             ] * self.n_bins
-        logger.debug("Discriminant cut: %s", self.disc_cut)
+        logger.debug("Discriminant cut: %.3f", self.disc_cut)
 
     def efficiency(self, x: np.ndarray, cut: float):
         """Calculate efficiency and the associated error.
@@ -268,7 +268,7 @@ class var_vs_eff(PlotLineObject):
         """
         logger.debug("Calculating signal efficiency.")
         eff = list(map(self.efficiency, self.disc_binned_sig, self.disc_cut))
-        logger.debug("Retrieved signal efficiencies: %s", eff)
+        logger.debug("Retrieved signal efficiencies: %.2f", eff)
         return np.array(eff)[:, 0], np.array(eff)[:, 1]
 
     @property
@@ -284,7 +284,7 @@ class var_vs_eff(PlotLineObject):
         """
         logger.debug("Calculating background efficiency.")
         eff = list(map(self.efficiency, self.disc_binned_bkg, self.disc_cut))
-        logger.debug("Retrieved background efficiencies: %s", eff)
+        logger.debug("Retrieved background efficiencies: %.2f", eff)
         return np.array(eff)[:, 0], np.array(eff)[:, 1]
 
     @property
@@ -300,7 +300,7 @@ class var_vs_eff(PlotLineObject):
         """
         logger.debug("Calculating signal rejection.")
         rej = list(map(self.rejection, self.disc_binned_sig, self.disc_cut))
-        logger.debug("Retrieved signal rejections: %s", rej)
+        logger.debug("Retrieved signal rejections: %.1f", rej)
         return np.array(rej)[:, 0], np.array(rej)[:, 1]
 
     @property
@@ -316,7 +316,7 @@ class var_vs_eff(PlotLineObject):
         """
         logger.debug("Calculating background rejection.")
         rej = list(map(self.rejection, self.disc_binned_bkg, self.disc_cut))
-        logger.debug("Retrieved background rejections: %s", rej)
+        logger.debug("Retrieved background rejections: %.1f", rej)
         return np.array(rej)[:, 0], np.array(rej)[:, 1]
 
     def __eq__(self, other):

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -152,12 +152,12 @@ class var_vs_eff(PlotLineObject):
             self.bin_edges = np.linspace(xmin, xmax, bins + 1)
         elif isinstance(bins, (list, np.ndarray)):
             self.bin_edges = np.array(bins)
-        logger.debug(f"Retrieved bin edges{self.bin_edges}")
+        logger.debug("Retrieved bin edges %s}", self.bin_edges)
         # Get the bins for the histogram
         self.x_bin_centres = (self.bin_edges[:-1] + self.bin_edges[1:]) / 2.0
         self.bin_widths = (self.bin_edges[1:] - self.bin_edges[:-1]) / 2.0
         self.n_bins = self.bin_edges.size - 1
-        logger.debug(f"N bins: {self.n_bins}")
+        logger.debug("N bins: %s", self.n_bins)
 
     def _apply_binning(self):
         """Get binned distributions for the signal and background."""
@@ -202,7 +202,7 @@ class var_vs_eff(PlotLineObject):
             self.disc_cut = [
                 np.percentile(self.disc_sig, (1 - self.wp) * 100)
             ] * self.n_bins
-        logger.debug(f"Discriminant cut: {self.disc_cut}")
+        logger.debug("Discriminant cut: %s", self.disc_cut)
 
     def efficiency(self, x: np.ndarray, cut: float):
         """Calculate efficiency and the associated error.
@@ -268,7 +268,7 @@ class var_vs_eff(PlotLineObject):
         """
         logger.debug("Calculating signal efficiency.")
         eff = list(map(self.efficiency, self.disc_binned_sig, self.disc_cut))
-        logger.debug(f"Retrieved signal efficiencies: {eff}")
+        logger.debug("Retrieved signal efficiencies: %s", eff)
         return np.array(eff)[:, 0], np.array(eff)[:, 1]
 
     @property
@@ -284,7 +284,7 @@ class var_vs_eff(PlotLineObject):
         """
         logger.debug("Calculating background efficiency.")
         eff = list(map(self.efficiency, self.disc_binned_bkg, self.disc_cut))
-        logger.debug(f"Retrieved background efficiencies: {eff}")
+        logger.debug("Retrieved background efficiencies: %s", eff)
         return np.array(eff)[:, 0], np.array(eff)[:, 1]
 
     @property
@@ -300,7 +300,7 @@ class var_vs_eff(PlotLineObject):
         """
         logger.debug("Calculating signal rejection.")
         rej = list(map(self.rejection, self.disc_binned_sig, self.disc_cut))
-        logger.debug(f"Retrieved signal rejections: {rej}")
+        logger.debug("Retrieved signal rejections: %s", rej)
         return np.array(rej)[:, 0], np.array(rej)[:, 1]
 
     @property
@@ -316,7 +316,7 @@ class var_vs_eff(PlotLineObject):
         """
         logger.debug("Calculating background rejection.")
         rej = list(map(self.rejection, self.disc_binned_bkg, self.disc_cut))
-        logger.debug(f"Retrieved background rejections: {rej}")
+        logger.debug("Retrieved background rejections: %s", rej)
         return np.array(rej)[:, 0], np.array(rej)[:, 1]
 
     def __eq__(self, other):
@@ -513,7 +513,7 @@ class var_vs_eff_plot(PlotBase):
         self.bin_edge_max = max(self.bin_edge_max, curve.bin_edges[-1])
 
         if reference:
-            logger.debug(f"Setting roc {key} as reference.")
+            logger.debug("Setting roc %s as reference.", key)
             self.set_reference(key)
 
     def set_reference(self, key: str):
@@ -528,8 +528,10 @@ class var_vs_eff_plot(PlotBase):
             self.reference_object = key
         else:
             logger.warning(
-                f"You specified a second curve {key} as reference for ratio. "
-                f"Using it as new reference instead of {self.reference_object}."
+                "You specified a second curve %s as reference for ratio. "
+                "Using it as new reference instead of %s.",
+                key,
+                self.reference_object,
             )
             self.reference_object = key
 
@@ -546,7 +548,7 @@ class var_vs_eff_plot(PlotBase):
         Line2D
             matplotlib Line2D object
         """
-        logger.debug(f"Plotting curves with mode {self.mode}")
+        logger.debug("Plotting curves with mode %s", self.mode)
         plt_handles = []
         for key in self.add_order:
             elem = self.plot_objects[key]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ log_level=INFO
 max-line-length = 88
 
 [pylint.'MESSAGES CONTROL']
-disable = fixme,invalid-name,logging-fstring-interpolation,too-many-arguments,duplicate-code,too-many-instance-attributes,unspecified-encoding,too-few-public-methods
+disable = fixme,invalid-name,too-many-arguments,duplicate-code,too-many-instance-attributes,unspecified-encoding,too-few-public-methods


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* stops ignoring `logging-fstring-interpolation` in pylint

Relates to the following issues

* First step towards #11 
