### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # puma - Plotting UMami Api
 
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) 
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Umami docs](https://img.shields.io/badge/info-documentation-informational)](https://umami-hep.github.io/puma/)
 [![PyPI version](https://badge.fury.io/py/puma-hep.svg)](https://badge.fury.io/py/puma-hep)
 
+![Testing workflow](https://github.com/umami-hep/puma/actions/workflows/testing.yml/badge.svg)
+![Linting workflow](https://github.com/umami-hep/puma/actions/workflows/linting.yml/badge.svg)
+![Pages workflow](https://github.com/umami-hep/puma/actions/workflows/pages.yml/badge.svg)
+
 The Python package `puma` provides a plotting API for commonly used plots in flavour tagging.
 
-ROC curves | Histogram plots | Variable vs efficiency |
-:---------:|:--------------: | :--------------------: |
-<img src=https://umami-docs.web.cern.ch/ci_assets/roc.png width=200> | <img src=https://umami-docs.web.cern.ch/ci_assets/histogram_discriminant.png width=220> | <img src=https://umami-docs.web.cern.ch/ci_assets/pt_light_rej.png width=220> |
-
+|                              ROC curves                              |                                     Histogram plots                                     |                            Variable vs efficiency                             |
+| :------------------------------------------------------------------: | :-------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------: |
+| <img src=https://umami-docs.web.cern.ch/ci_assets/roc.png width=200> | <img src=https://umami-docs.web.cern.ch/ci_assets/histogram_discriminant.png width=220> | <img src=https://umami-docs.web.cern.ch/ci_assets/pt_light_rej.png width=220> |
 
 ## Installation
 
 The `puma` package is currently under construction. It can be installed from PyPI or
 using the latest code from this repository.
 
-```bash   
+```bash
 pip install puma-hep
 # or
 pip install https://github.com/umami-hep/puma/archive/master.tar.gz

--- a/README.md
+++ b/README.md
@@ -19,8 +19,22 @@ The Python package `puma` provides a plotting API for commonly used plots in fla
 The `puma` package is currently under construction. It can be installed from PyPI or
 using the latest code from this repository.
 
-```bash
+### Install latest release from PyPI
+
+```bash   
 pip install puma-hep
-# or
+```
+
+The installation from PyPI only allows to install tagged releases, meaning you can not
+install the latest code from this repo using the above command.
+If you just want to use a stable release of `puma`, this is the way to go.
+
+### Install latest version from GitHub
+```bash   
 pip install https://github.com/umami-hep/puma/archive/master.tar.gz
 ```
+
+This will install the latest version of `puma`, i.e. the current version
+from the `main` branch (no matter if it is a release/tagged commit).
+If you plan on contributing to `puma` and/or want the latest version possible, this
+is what you want.

--- a/docs/source/module_reference.rst
+++ b/docs/source/module_reference.rst
@@ -1,17 +1,54 @@
 
+****************
 Module reference
-================
+****************
 
-puma
-----
-.. automodule:: puma
+Plot base
+=========
+
+`PlotBase`
+----------
+.. autoclass:: puma.PlotBase
    :members:
    :show-inheritance:
-   
+`PlotObject`
+------------
+.. autoclass:: puma.PlotObject
+   :members:
+   :show-inheritance:
+`PlotLineObject`
+----------------
+.. autoclass:: puma.PlotLineObject
+   :members:
+   :show-inheritance:
 ______
 
-puma.base
+Histograms
+==========
+
+`Histogram`
+-----------
+.. autoclass:: puma.Histogram
+   :members:
+   :show-inheritance:
+
+`HistogramPlot`
+---------------
+.. autoclass:: puma.HistogramPlot
+   :members:
+   :show-inheritance:
+______
+
+ROC curves
+==========
+
+`Roc`
+-----
+.. autoclass:: puma.Roc
+   :members:
+   :show-inheritance:
+`RocPlot`
 ---------
-.. automodule:: puma.base
+.. autoclass:: puma.RocPlot
    :members:
    :show-inheritance:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ zip_safe = False
 include_package_data = True
 python_requires = >= 3.8
 install_requires=
-    atlasify>=0.7.1
+    atlasify==0.7.1
     matplotlib>=3.5.1
     numpy>=1.21.0
     pandas>=1.3.5


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Using `autoclass` instead of `automodule` for now in the Sphinx documentation, since this puts the short names (e.g. `puma.Histogram` instead of `puma.histogram.Histogram`) in the docs
* Adding badges for status of GitHub Actions workflows

Relates to the following issues

* #3 

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
