### PR TITLE
Set new default `n_ratio_panels=0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Latest
 
+- Set default number of ratio panels to 0 [#17](https://github.com/umami-hep/puma/pull/17)
 - Adding uncertainties to Roc main plots and improving dummy data generator [#14](https://github.com/umami-hep/puma/pull/14)
 - Fixing all PEP8 related variable namings [#13](https://github.com/umami-hep/puma/pull/13)
 - Adding FractionScan to puma [#8](https://github.com/umami-hep/puma/pull/8)

--- a/examples/plot_pt_vs_eff.py
+++ b/examples/plot_pt_vs_eff.py
@@ -103,6 +103,7 @@ plot_bkg_rej = VarVsEffPlot(
         "$\\sqrt{s}=13$ TeV, dummy jets, \n$t\\bar{t}$ test sample, $f_{c}=0.018$"
     ),
     figsize=(6, 4.5),
+    n_ratio_panels=1,
 )
 plot_bkg_rej.add(rnnip_light, reference=True)
 plot_bkg_rej.add(dips_light)

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -102,7 +102,7 @@ class PlotObject:
     fontsize : int, optional
         Used fontsize, by default 10
     n_ratio_panels : int, optional
-        Amount of ratio panels between 0 and 2, by default 1
+        Amount of ratio panels between 0 and 2, by default 0
     vertical_split: bool
         Set to False if you would like to split the figure horizonally. If set to
         True the figure is split vertically (e.g for pie chart). By default False.
@@ -161,7 +161,7 @@ class PlotObject:
     label_fontsize: int = 12
     fontsize: int = 10
 
-    n_ratio_panels: int = 1
+    n_ratio_panels: int = 0
     vertical_split: bool = False
 
     figsize: tuple = None

--- a/puma/tests/test_histogram.py
+++ b/puma/tests/test_histogram.py
@@ -136,6 +136,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             atlas_second_tag="",
             figsize=(5, 4),
             ylabel="Number of jets",
+            n_ratio_panels=1,
         )
         hist_plot.add(self.hist_1, reference=True)
         hist_plot.draw()
@@ -155,7 +156,12 @@ class histogram_plot_TestCase(unittest.TestCase):
 
     def test_output_ratio(self):
         """check with a plot if the ratio is the expected value"""
-        hist_plot = HistogramPlot(norm=False, ymax_ratio_1=4, figsize=(6.5, 5))
+        hist_plot = HistogramPlot(
+            norm=False,
+            ymax_ratio_1=4,
+            figsize=(6.5, 5),
+            n_ratio_panels=1,
+        )
         hist_plot.add(self.hist_1, reference=True)
         hist_plot.add(self.hist_2)
         hist_plot.draw()
@@ -182,6 +188,7 @@ class histogram_plot_TestCase(unittest.TestCase):
                 "Test if ratio is 1 for whole range if reference histogram is empty\n"
                 "(+ normalised)"
             ),
+            n_ratio_panels=1,
         )
         hist_plot.add(Histogram(np.array([]), label="empty histogram"), reference=True)
         hist_plot.add(self.hist_1)
@@ -207,6 +214,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             atlas_second_tag=(
                 "Test if ratio is 1 for whole range if reference histogram is empty"
             ),
+            n_ratio_panels=1,
         )
         hist_plot.add(Histogram(np.array([]), label="empty histogram"), reference=True)
         hist_plot.add(self.hist_1)
@@ -236,6 +244,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             figsize=(7, 6),
             leg_loc="upper right",
             y_scale=1.5,
+            n_ratio_panels=1,
         )
         np.random.seed(42)
         n_random = 10_000
@@ -277,6 +286,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             atlas_second_tag="",
             figsize=(5, 4),
             ylabel="Number of jets",
+            n_ratio_panels=1,
         )
         hist_plot.add(self.hist_1, reference=True)
         hist_plot.draw_vlines(
@@ -306,6 +316,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             atlas_second_tag="",
             figsize=(5, 4),
             ylabel="Number of jets",
+            n_ratio_panels=1,
         )
         hist_plot.add(self.hist_1, reference=True)
         hist_plot.draw_vlines(
@@ -336,6 +347,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             atlas_second_tag="",
             figsize=(5, 4),
             ylabel="Number of jets",
+            n_ratio_panels=1,
         )
         hist_plot.add(self.hist_1, reference=True)
         hist_plot.draw_vlines(
@@ -366,6 +378,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             atlas_second_tag="",
             figsize=(5, 4),
             ylabel="Number of jets",
+            n_ratio_panels=1,
         )
         hist_plot.add(self.hist_1, reference=True)
         hist_plot.draw_vlines(

--- a/puma/tests/test_var_vs_eff.py
+++ b/puma/tests/test_var_vs_eff.py
@@ -300,6 +300,7 @@ class var_vs_eff_output_TestCase(unittest.TestCase):
                 "'better model' should have quite large bkg efficiency $p_T > 110$\n"
             ),
             y_scale=1.5,
+            n_ratio_panels=1,
         )
         plot_bkg_rej.add(ref_light, reference=True)
         plot_bkg_rej.add(better_light)
@@ -356,6 +357,7 @@ class var_vs_eff_output_TestCase(unittest.TestCase):
                 "'better model' should have bkg efficiency of ~ 0 for $p_T > 110$\n"
             ),
             y_scale=1.5,
+            n_ratio_panels=1,
         )
         plot_bkg_rej.add(ref_light, reference=True)
         plot_bkg_rej.add(better_light)

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -679,7 +679,8 @@ class VarVsEffPlot(PlotBase):
             self.bin_edge_max if self.xmax is None else self.xmax,
         )
         plt_handles = self.plot()
-        self.plot_ratios()
+        if self.n_ratio_panels == 1:
+            self.plot_ratios()
         self.set_title()
         self.set_logy()
         self.set_y_lim()


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Sets the default for the number of ratio panels to 0

Relates to the following issues

* Closes #4 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
