### PR TITLE
Use example plots from this repo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install rsync
         run: apt update && apt install -y rsync
           
-      # This workflow will only update the gh-pages branch if the documentation
+      # This action will only update the gh-pages branch if the documentation
       # is affected by the changes that triggered the job
       - name: Deploy to GitHub pages
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build Sphinx documentation
         run: bash docs/build_docs.sh
 
-      # rsync is needed for the subsequently used workflow
+      # rsync is needed for the subsequently used action
       - name: Install rsync
         run: apt update && apt install -y rsync
           

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
       # This action will only update the examples-material branch if it
       # is affected by the changes that triggered the job
       - name: Install deployment dependencies
-        run: apt install -y rsync git
+        run: apt update && apt install -y rsync git
       - name: Upload examples-material
         if: ${{ github.event_name == 'push' }}
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,7 @@ jobs:
   example_tests:
     name: Example tests
     runs-on: ubuntu-latest
-    container: python:3.8-slim
+    container: python:3.8
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -28,14 +28,13 @@ jobs:
       - run: pip install .
       - run: mkdir plots
       - run: cd plots && for f in ../examples/*.py; do python "$f"; done
-      - uses: actions/upload-artifact@v3
-        with:
-          name: plot-example-artifacts
-          path: plots/*.png
       # This action will only update the examples-material branch if it
       # is affected by the changes that triggered the job
-      - name: Install deployment dependencies
-        run: apt update && apt install -y rsync git
+      # rsync is needed for the subsequently used workflow
+      - name: Install rsync
+        run: apt update && apt install -y rsync
+      # - name: Install dependencies
+      #   run: apt update && apt install -y rsync git
       - name: Upload examples-material
         if: ${{ github.event_name == 'push' }}
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,6 +32,14 @@ jobs:
         with:
           name: plot-example-artifacts
           path: plots/*.png
+      # This action will only update the examples-material branch if it
+      # is affected by the changes that triggered the job
+      - name: Upload examples-material
+        if: ${{ github.event_name == 'push' }}
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          BRANCH: examples-material
+          FOLDER: plots
   publish:
     name: Publish to PyPI
     needs: [unit_tests]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,6 +34,8 @@ jobs:
           path: plots/*.png
       # This action will only update the examples-material branch if it
       # is affected by the changes that triggered the job
+      - name: Install deployment dependencies
+        run: apt-install -y rsync git
       - name: Upload examples-material
         if: ${{ github.event_name == 'push' }}
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
       # This action will only update the examples-material branch if it
       # is affected by the changes that triggered the job
       - name: Install deployment dependencies
-        run: apt-install -y rsync git
+        run: apt install -y rsync git
       - name: Upload examples-material
         if: ${{ github.event_name == 'push' }}
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,13 +28,11 @@ jobs:
       - run: pip install .
       - run: mkdir plots
       - run: cd plots && for f in ../examples/*.py; do python "$f"; done
-      # This action will only update the examples-material branch if it
-      # is affected by the changes that triggered the job
-      # rsync is needed for the subsequently used workflow
+      # rsync is needed for the subsequently used action
       - name: Install rsync
         run: apt update && apt install -y rsync
-      # - name: Install dependencies
-      #   run: apt update && apt install -y rsync git
+      # This action will only update the examples-material branch if it
+      # is affected by the changes that triggered the job
       - name: Upload examples-material
         if: ${{ github.event_name == 'push' }}
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
       # This action will only update the examples-material branch if it
       # is affected by the changes that triggered the job
       - name: Upload examples-material
-        if: ${{ github.event_name == 'push' }}
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           BRANCH: examples-material

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The Python package `puma` provides a plotting API for commonly used plots in fla
 
 |                              ROC curves                              |                                     Histogram plots                                     |                            Variable vs efficiency                             |
 | :------------------------------------------------------------------: | :-------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------: |
-| <img src=https://umami-docs.web.cern.ch/ci_assets/roc.png width=200> | <img src=https://umami-docs.web.cern.ch/ci_assets/histogram_discriminant.png width=220> | <img src=https://umami-docs.web.cern.ch/ci_assets/pt_light_rej.png width=220> |
+| <img src=https://github.com/umami-hep/puma/raw/examples-material/roc.png width=200> | <img src=https://github.com/umami-hep/puma/raw/examples-material/histogram_discriminant.png width=220> | <img src=https://github.com/umami-hep/puma/raw/examples-material/pt_b_eff.png width=220> |
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Python package `puma` provides a plotting API for commonly used plots in fla
 
 |                              ROC curves                              |                                     Histogram plots                                     |                            Variable vs efficiency                             |
 | :------------------------------------------------------------------: | :-------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------: |
-| <img src=https://github.com/umami-hep/puma/raw/examples-material/roc.png width=200> | <img src=https://github.com/umami-hep/puma/raw/examples-material/histogram_discriminant.png width=220> | <img src=https://github.com/umami-hep/puma/raw/examples-material/pt_b_eff.png width=220> |
+| <img src=https://github.com/umami-hep/puma/raw/examples-material/roc.png width=200> | <img src=https://github.com/umami-hep/puma/raw/examples-material/histogram_discriminant.png width=220> | <img src=https://github.com/umami-hep/puma/raw/examples-material/pt_light_rej.png width=220> |
 
 
 ## Installation


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* the output of the example scripts is now pushed to a branch called `examples-material`. This allows us to easily use these images in the README and docs (just use the raw/download link of the image)

Relates to the following issues

* #1 
