### PR TITLE
Removing warning for multiple reference histograms + adding tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### Latest
 
+- Remove warning when adding more than one reference histogram is case is allowed [#32](https://github.com/umami-hep/puma/pull/32)
 - Update documentation [#24](https://github.com/umami-hep/puma/pull/24)
 
 ### [v0.1.0]

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -72,7 +72,7 @@ class Histogram(PlotLineObject):
             kwargs["label"] if "label" in kwargs and kwargs["label"] is not None else ""
         )
         # If flavour was specified, extract configuration from global config
-        if self.flavour is not None:
+        if self.colour is None and self.flavour is not None:
             self.colour = global_config["flavour_categories"][self.flavour]["colour"]
             logger.debug("Histogram colour was set to %s", self.colour)
 
@@ -216,12 +216,12 @@ class HistogramPlot(PlotBase):
             raise ValueError("Not more than one ratio panel supported.")
         self.initialise_figure(sub_plot_index=6)
 
-    def add(self, curve: object, key: str = None, reference: bool = False):
+    def add(self, histogram: object, key: str = None, reference: bool = False):
         """Adding histogram object to figure.
 
         Parameters
         ----------
-        curve : histogram class
+        histogram : Histogram class
             Histogram curve
         key : str, optional
             Unique identifier for histogram, by default None
@@ -240,23 +240,23 @@ class HistogramPlot(PlotBase):
             raise KeyError(f"Duplicated key {key} already used for unique identifier.")
 
         # Add key to histogram object
-        curve.key = key
+        histogram.key = key
         logger.debug("Adding histogram %s", key)
 
         # Set linestyle
-        if curve.linestyle is None:
-            curve.linestyle = "-"
+        if histogram.linestyle is None:
+            histogram.linestyle = "-"
         # Set colours
-        if curve.colour is None:
-            curve.colour = get_good_colours()[len(self.plot_objects)]
+        if histogram.colour is None:
+            histogram.colour = get_good_colours()[len(self.plot_objects)]
         # Set alpha
-        if curve.alpha is None:
-            curve.alpha = 0.8
+        if histogram.alpha is None:
+            histogram.alpha = 0.8
         # Set linewidth
-        if curve.linewidth is None:
-            curve.linewidth = 1.6
+        if histogram.linewidth is None:
+            histogram.linewidth = 1.6
 
-        self.plot_objects[key] = curve
+        self.plot_objects[key] = histogram
         self.add_order.append(key)
         if reference is True:
             self.set_reference(key)

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -271,16 +271,9 @@ class HistogramPlot(PlotBase):
         """
         if self.reference_object is None:
             self.reference_object = [key]
-            logger.info("Using '%s' as reference histogram", key)
         else:
             self.reference_object.append(key)
-            logger.warning(
-                "You specified another curve %s as reference for ratio. "
-                "Adding it to reference histograms. "
-                "New list of reference histograms: %s",
-                key,
-                self.reference_object,
-            )
+        logger.debug("Adding '%s' to reference histogram(s)", key)
 
     def plot(self, **kwargs):
         """Plotting curves. This also generates the bins of the histograms that are

--- a/puma/tests/test_histogram.py
+++ b/puma/tests/test_histogram.py
@@ -122,6 +122,28 @@ class histogram_plot_TestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             hist_plot.add_bin_width_to_ylabel()
 
+    def test_multiple_references_no_flavour(self):
+        """Tests if error is raised in case of non-unique reference histogram"""
+        hist_plot = HistogramPlot(n_ratio_panels=1)
+        hist_plot.add(self.hist_1, reference=True)
+        hist_plot.add(self.hist_2, reference=True)
+        hist_plot.add(self.hist_1)
+        hist_plot.plot()
+        with self.assertRaises(ValueError):
+            hist_plot.plot_ratios()
+
+    def test_multiple_references_flavour(self):
+        """Tests if error is raised in case of non-unique reference histogram
+        when flavoured histograms are used"""
+        hist_plot = HistogramPlot(n_ratio_panels=1)
+        dummy_array = np.array([1, 1, 2, 3, 2, 3])
+        hist_plot.add(Histogram(dummy_array, flavour="ujets"), reference=True)
+        hist_plot.add(Histogram(dummy_array, flavour="ujets"), reference=True)
+        hist_plot.add(Histogram(dummy_array, flavour="ujets"))
+        hist_plot.plot()
+        with self.assertRaises(ValueError):
+            hist_plot.plot_ratios()
+
     def test_custom_range(self):
         """check if
         1. bins_range argument is used correctly


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Removing warning when adding more than one reference histograms (this is often what we want, since we have one reference histogram per flavour)
* Adding unit tests for cases where multiple reference histograms are provided *for the same flavour*
* Only use the default colour of a flavour if no colour was specified in a `puma.Histogram` object

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
