### PR TITLE
Add warning if ylabel does not contain "norm"

### DIFF
--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -295,6 +295,11 @@ class HistogramPlot(PlotBase):
         ValueError
             If specified bins type is not supported.
         """
+        if self.norm and "norm" not in self.ylabel.lower():
+            logger.warning(
+                "You are plotting normalised distributions but 'norm' is not "
+                "included in your y-label."
+            )
         plt_handles = []
 
         # Calculate bins of stacked histograms to ensure all histograms fit in plot


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* add warning if ylabel does not contain "norm" but normalised histograms are plotted

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
