### PR TITLE
Fix that colour and label can be modified in case of flavoured histogram

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Fix that colour and legend label can be individually modified in case of flavoured histogram [#57](https://github.com/umami-hep/puma/pull/57)
 
 ### [v0.1.1]
 

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -72,15 +72,20 @@ class Histogram(PlotLineObject):
             kwargs["label"] if "label" in kwargs and kwargs["label"] is not None else ""
         )
         # If flavour was specified, extract configuration from global config
-        if self.colour is None and self.flavour is not None:
-            self.colour = global_config["flavour_categories"][self.flavour]["colour"]
-            logger.debug("Histogram colour was set to %s", self.colour)
-
-            self.label = (
-                f"{global_config['flavour_categories'][self.flavour]['legend_label']}"
-                f" {self.label_addition}"
-            )
-            logger.debug("Histogram label was set to %s", {self.label})
+        if self.flavour is not None:
+            # Use globally defined flavour colour if not specified
+            if self.colour is None:
+                self.colour = global_config["flavour_categories"][self.flavour][
+                    "colour"
+                ]
+                logger.debug("Histogram colour was set to %s", self.colour)
+            # Use globally defined flavour label if not specified
+            if self.label is None:
+                global_flavour_label = global_config["flavour_categories"][
+                    self.flavour
+                ]["legend_label"]
+                self.label = f"{global_flavour_label} {self.label_addition}"
+                logger.debug("Histogram label was set to %s", {self.label})
 
     def divide(self, other):
         """Calculate ratio between two class objects.


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Until now, both the legend label and the linecolour of a flavoured `puma.Histogram` were overwritten with the values from the global config. They can now be overwritten individually (i.e. changing the linecolour won't affect the default label and vice versa)

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] ~[Documentation](https://umami-hep.github.io/puma/)~
