### PR TITLE
correction of warning message

### DIFF
--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -268,9 +268,9 @@ class PlotBase(PlotObject):
 
         if self.vertical_split:
             # split figure vertically instead of horizonally
-            if self.n_ratio_panels <= 1:
+            if self.n_ratio_panels >= 1:
                 logger.warning(
-                    "You set the number of ratio panels to %i"
+                    "You set the number of ratio panels to %i "
                     "but also set the vertical splitting to True. Therefore no ratio"
                     "panels are created.",
                     self.n_ratio_panels,


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* correction of warning message if the number of ratio panels is set to >= 1 put also the vertical split of the plot is set to true (in order to plot a pie chart)

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
