### PR TITLE
pylint improvements

### DIFF
--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -146,7 +146,7 @@ class Histogram(
 class HistogramPlot(PlotBase):  # pylint: disable=too-many-instance-attributes
     """Histogram plot class"""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         bins=40,
         bins_range: tuple = None,

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -8,7 +8,7 @@ from puma.utils import get_good_colours, get_good_pie_colours, global_config, lo
 from puma.utils.histogram import hist_ratio, hist_w_unc
 
 
-class Histogram(PlotLineObject):
+class Histogram(PlotLineObject):  # pylint: disable=too-few-public-methods
     """
     Histogram class storing info about histogram and allows to calculate ratio w.r.t
     other histograms.

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -8,7 +8,9 @@ from puma.utils import get_good_colours, get_good_pie_colours, global_config, lo
 from puma.utils.histogram import hist_ratio, hist_w_unc
 
 
-class Histogram(PlotLineObject):  # pylint: disable=too-few-public-methods
+class Histogram(
+    PlotLineObject
+):  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """
     Histogram class storing info about histogram and allows to calculate ratio w.r.t
     other histograms.
@@ -141,7 +143,7 @@ class Histogram(PlotLineObject):  # pylint: disable=too-few-public-methods
         return (ratio, ratio_unc)
 
 
-class HistogramPlot(PlotBase):
+class HistogramPlot(PlotBase):  # pylint: disable=too-many-instance-attributes
     """Histogram plot class"""
 
     def __init__(

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -59,7 +59,7 @@ class PlotLineObject:  # pylint: disable=too-many-instance-attributes
 # TODO: enable `kw_only` when switching to Python 3.10
 # @dataclass(kw_only=True)
 @dataclass
-class PlotObject:
+class PlotObject:  # pylint: disable=too-many-instance-attributes
     """Data base class defining properties of a plot object.
 
     Parameters
@@ -235,7 +235,7 @@ class PlotObject:
             )
 
 
-class PlotBase(PlotObject):
+class PlotBase(PlotObject):  # pylint: disable=too-many-instance-attributes
     """Base class for plotting"""
 
     def __init__(self, **kwargs) -> None:

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -329,7 +329,7 @@ class PlotBase(PlotObject):  # pylint: disable=too-many-instance-attributes
         same_height: bool = False,
         colour: str = "#920000",
         fontsize: int = 10,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Drawing working points in plot
 
         Parameters

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -184,7 +184,7 @@ class Roc(PlotLineObject):
         return self.sig_eff[self.non_zero_mask], self.bkg_rej[self.non_zero_mask]
 
 
-class RocPlot(PlotBase):
+class RocPlot(PlotBase):  # pylint: disable=too-many-instance-attributes
     """ROC plot class"""
 
     def __init__(self, **kwargs) -> None:

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -14,7 +14,7 @@ class Roc(PlotLineObject):
     ROC class storing info about curve and allows to calculate ratio w.r.t other roc.
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         sig_eff: np.ndarray,
         bkg_rej: np.ndarray,

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -9,7 +9,7 @@ from puma.utils import get_good_colours, logger
 from puma.utils.histogram import hist_ratio, save_divide
 
 
-class VarVsEff(PlotLineObject):
+class VarVsEff(PlotLineObject):  # pylint: disable=too-many-instance-attributes
     """
     var_vs_eff class storing info about curve and allows to calculate ratio w.r.t other
     efficiency plots.
@@ -430,7 +430,7 @@ class VarVsEff(PlotLineObject):
         )
 
 
-class VarVsEffPlot(PlotBase):
+class VarVsEffPlot(PlotBase):  # pylint: disable=too-many-instance-attributes
     """var_vs_eff plot class"""
 
     def __init__(self, mode, **kwargs) -> None:

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -15,7 +15,7 @@ class VarVsEff(PlotLineObject):  # pylint: disable=too-many-instance-attributes
     efficiency plots.
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         x_var_sig: np.ndarray,
         disc_sig: np.ndarray,

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ log_level=INFO
 max-line-length = 88
 
 [pylint.'MESSAGES CONTROL']
-disable = fixme,too-many-arguments,duplicate-code,too-many-instance-attributes
+disable = fixme,too-many-arguments,duplicate-code

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ log_level=INFO
 max-line-length = 88
 
 [pylint.'MESSAGES CONTROL']
-disable = fixme,too-many-arguments,duplicate-code,too-many-instance-attributes,unspecified-encoding,too-few-public-methods
+disable = fixme,too-many-arguments,duplicate-code,too-many-instance-attributes,unspecified-encoding

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ log_level=INFO
 max-line-length = 88
 
 [pylint.'MESSAGES CONTROL']
-disable = fixme,too-many-arguments,duplicate-code,too-many-instance-attributes,unspecified-encoding
+disable = fixme,too-many-arguments,duplicate-code,too-many-instance-attributes

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ log_level=INFO
 max-line-length = 88
 
 [pylint.'MESSAGES CONTROL']
-disable = fixme,too-many-arguments,duplicate-code
+disable = fixme,duplicate-code


### PR DESCRIPTION
## Summary

From now on, the following pylint warnings are *not* ignored globally anymore

* too-many-arguments
* too-many-instance-attributes
* unspecified-encoding
* too-few-public-methods

Relates to the following issues

* next step towards #11 
