### PR TITLE
Fix pytest job not failing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: pytest-coverage-comment
+name: Coverage
 on:
   pull_request:
     branches:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,26 @@
+name: pytest-coverage-comment
+on:
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  unit_tests:
+    name: Check coverage
+    runs-on: ubuntu-latest
+    container: python:3.8-slim
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - run: pip install -e . # install in editable mode for coverage to work
+      - run: pip install flake8 pytest pytest-cov
+      - name: Create output for coverage comment
+        run: pytest -v --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=puma puma/tests/ | tee pytest-coverage.txt
+      - name: Post coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: ./pytest-coverage.txt
+          junitxml-path: ./pytest.xml
+          create-new-comment: false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
+          create-new-comment: false
       - name: Run pytest  # we have to run pytest here again, since the previous steps don't fail even if a test fails (due to the pipe)
         run: pytest -v puma/tests/
   example_tests:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,26 +14,12 @@ jobs:
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - run: pip install -e . # install in editable mode for coverage to work
       - run: pip install flake8 pytest pytest-cov
-      - run: pytest -v puma/tests/
-  coverage:
-    name: Check coverage
-    runs-on: ubuntu-latest
-    container: python:3.8-slim
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
-      - run: pip install -e . # install in editable mode for coverage to work
-      - run: pip install flake8 pytest pytest-cov
       - run: pytest -v --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=puma puma/tests/ | tee pytest-coverage.txt
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
-          create-new-comment: false
   example_tests:
     name: Example tests
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,12 +14,15 @@ jobs:
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - run: pip install -e . # install in editable mode for coverage to work
       - run: pip install flake8 pytest pytest-cov
-      - run: pytest -v --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=puma puma/tests/ | tee pytest-coverage.txt
-      - name: Pytest coverage comment
+      - name: Create output for coverage comment
+        run: pytest -v --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=puma puma/tests/ | tee pytest-coverage.txt
+      - name: Post coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
+      - name: Run pytest  # we have to run pytest here again, since the previous steps don't fail even if a test fails (due to the pipe)
+        run: pytest -v puma/tests/
   example_tests:
     name: Example tests
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,12 +14,26 @@ jobs:
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - run: pip install -e . # install in editable mode for coverage to work
       - run: pip install flake8 pytest pytest-cov
+      - run: pytest -v puma/tests/
+  coverage:
+    name: Check coverage
+    runs-on: ubuntu-latest
+    container: python:3.8-slim
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - run: pip install -e . # install in editable mode for coverage to work
+      - run: pip install flake8 pytest pytest-cov
       - run: pytest -v --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=puma puma/tests/ | tee pytest-coverage.txt
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
+          create-new-comment: false
   example_tests:
     name: Example tests
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,10 +12,9 @@ jobs:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
-      - run: pip install -e . # install in editable mode for coverage to work
-      - run: pip install flake8 pytest
-      - name: Run pytest  # we have to run pytest here again, since the previous steps don't fail even if a test fails (due to the pipe)
-        run: pytest -v puma/tests/
+      - run: pip install -e . # install in editable mode
+      - run: pip install pytest
+      - run: pytest -v puma/tests/
   example_tests:
     name: Example tests
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,15 +13,7 @@ jobs:
       - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - run: pip install -e . # install in editable mode for coverage to work
-      - run: pip install flake8 pytest pytest-cov
-      - name: Create output for coverage comment
-        run: pytest -v --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=puma puma/tests/ | tee pytest-coverage.txt
-      - name: Post coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
-        with:
-          pytest-coverage-path: ./pytest-coverage.txt
-          junitxml-path: ./pytest.xml
-          create-new-comment: false
+      - run: pip install flake8 pytest
       - name: Run pytest  # we have to run pytest here again, since the previous steps don't fail even if a test fails (due to the pipe)
         run: pytest -v puma/tests/
   example_tests:

--- a/puma/tests/test_histogram.py
+++ b/puma/tests/test_histogram.py
@@ -399,7 +399,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             atlas_first_tag="Simulation, $\\sqrt{s}=13$ TeV",
             atlas_second_tag="",
             figsize=(5, 4),
-            ylabel="Number of jets",
+            ylabel="Number of jets test",
             n_ratio_panels=1,
         )
         hist_plot.add(self.hist_1, reference=True)

--- a/puma/tests/test_histogram.py
+++ b/puma/tests/test_histogram.py
@@ -399,7 +399,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             atlas_first_tag="Simulation, $\\sqrt{s}=13$ TeV",
             atlas_second_tag="",
             figsize=(5, 4),
-            ylabel="Number of jets test",
+            ylabel="Number of jets",
             n_ratio_panels=1,
         )
         hist_plot.add(self.hist_1, reference=True)


### PR DESCRIPTION
## Summary

This pull request adds another job to the CI that takes care of the coverage comment. This has two advantages:

1.   Running `pytest` without piping the output to a txt file, since otherwise the unit test job does not fail even if tests fail (it would just show up in the comment created by the bot)
2.   From now on, the coverage comment is only posted on pull requests
3.   The coverage comment is edited after a new commit is pushed instead of posting a new commit (check the last comment in this PR to see this)