### PR TITLE
Remove that `ratio_group` is set via `flavour`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ### Latest
 
-- `ratio_group` can no longer be set via `flavour` argument [#74](https://github.com/umami-hep/puma/pull/74)
+- `ratio_group` in `puma.Histogram` objects can no longer be set via `flavour` argument [#74](https://github.com/umami-hep/puma/pull/74)
+
 - Adding example for `plt.show` replacement + adding theme switcher button to docs [#72](https://github.com/umami-hep/puma/pull/72)
 - Adding `atlas_tag_outside` and change default for `atlas_second_tag` [#71](https://github.com/umami-hep/puma/pull/71)
 - Change default *bb*-jets colour to dark red and vlines to black [#69](https://github.com/umami-hep/puma/pull/69)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### Latest
 
+- `ratio_group` can no longer be set via `flavour` argument [#74](https://github.com/umami-hep/puma/pull/74)
 - Adding example for `plt.show` replacement + adding theme switcher button to docs [#72](https://github.com/umami-hep/puma/pull/72)
 - Adding `atlas_tag_outside` and change default for `atlas_second_tag` [#71](https://github.com/umami-hep/puma/pull/71)
 - Change default *bb*-jets colour to dark red and vlines to black [#69](https://github.com/umami-hep/puma/pull/69)

--- a/examples/plot_discriminant_scores.py
+++ b/examples/plot_discriminant_scores.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from puma import Histogram, HistogramPlot
-from puma.utils import get_dummy_2_taggers
+from puma.utils import get_dummy_2_taggers, global_config
 
 # The line below generates dummy data which is similar to a NN output
 df = get_dummy_2_taggers()
@@ -22,44 +22,44 @@ is_light = df["HadronConeExclTruthLabelID"] == 0
 is_c = df["HadronConeExclTruthLabelID"] == 4
 is_b = df["HadronConeExclTruthLabelID"] == 5
 
+flav_cat = global_config["flavour_categories"]
+
 hist_dips_light = Histogram(
     df[is_light]["disc_dips"],
-    flavour="ujets",
-    label="DIPS",
-    # if not set, the "ratio_group" argument would be set to the flavour "ujets"
-    # so this is just done here for demonstration purposes
+    label="Light-flavour jets DIPS",
+    colour=flav_cat["ujets"]["colour"],
     ratio_group="ujets",
 )
 hist_dips_c = Histogram(
     df[is_c]["disc_dips"],
-    flavour="cjets",
-    label="DIPS",
+    label="$c$-jets DIPS",
+    colour=flav_cat["cjets"]["colour"],
     ratio_group="cjets",
 )
 hist_dips_b = Histogram(
     df[is_b]["disc_dips"],
-    flavour="bjets",
-    label="DIPS",
+    label="$b$-jets DIPS",
+    colour=flav_cat["bjets"]["colour"],
     ratio_group="bjets",
 )
 hist_rnnip_light = Histogram(
     df[is_light]["disc_rnnip"],
-    flavour="ujets",
-    label="RNNIP",
+    label="Light-flavour jets RNNIP",
+    colour=flav_cat["ujets"]["colour"],
     linestyle="dashed",
     ratio_group="ujets",
 )
 hist_rnnip_c = Histogram(
     df[is_c]["disc_rnnip"],
-    flavour="cjets",
-    label="RNNIP",
+    label="$c$-jets RNNIP",
+    colour=flav_cat["cjets"]["colour"],
     linestyle="dashed",
     ratio_group="cjets",
 )
 hist_rnnip_b = Histogram(
     df[is_b]["disc_rnnip"],
-    flavour="bjets",
-    label="RNNIP",
+    label="$b$-jets RNNIP",
+    colour=flav_cat["bjets"]["colour"],
     linestyle="dashed",
     ratio_group="bjets",
 )

--- a/examples/plot_flavour_probabilities.py
+++ b/examples/plot_flavour_probabilities.py
@@ -16,7 +16,7 @@ plot_histo = HistogramPlot(
     figsize=(6, 4.5),
     atlas_first_tag="Simulation, $\\sqrt{s}=13$ TeV",
     atlas_second_tag="dummy sample, dummy jets",
-    atlas_brand=None,
+    atlas_brand=None,  # You can deactivate the ATLAS branding (e.g. for a thesis)
     draw_errors=False,
     # bins=np.linspace(0, 1, 30),  # you can also force a binning for the plot here
 )
@@ -26,6 +26,8 @@ u_jets = df.query("HadronConeExclTruthLabelID==0")
 c_jets = df.query("HadronConeExclTruthLabelID==4")
 b_jets = df.query("HadronConeExclTruthLabelID==5")
 
+# the "flavour" argument will add a "light-flavour jets" (or other) prefix to the label
+# + set the colour to the one that is defined in puma.utils.global_config
 plot_histo.add(Histogram(u_jets["dips_pb"], flavour="ujets"))
 plot_histo.add(Histogram(c_jets["dips_pb"], flavour="cjets"))
 plot_histo.add(Histogram(b_jets["dips_pb"], flavour="bjets"))

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -36,20 +36,20 @@ class Histogram(
             allows you to compare different groups of histograms within one plot.
             By default None
         flavour: str, optional
-            Jet flavour in case the histogram corresponds to one specific flavour. If
-            this is specified, the correct colour will be extracted from the global
-            config. Allowed values are the ones from the global config, i.e. "bjets",
-            "cjets", "ujets", "bbjets", ..., by default None
+            If set, the correct colour and a label prefix will be extracted from
+            `puma.utils.global_config` set for this histogram.
+            Allowed values are e.g. "bjets", "cjets", "ujets", "bbjets", ...
+            By default None
         add_flavour_label : bool, optional
             Set to False to suppress the automatic addition of the flavour label prefix
             in the label of the curve (i.e. "$b$-jets" in the case of b-jets).
-            This is ignored if `flavour` is not set. By default False
+            This is ignored if `flavour` is not set. By default True
         histtype: str, optional
             `histtype` parameter which is handed to matplotlib.hist() when plotting the
             histograms. Supported values are "bar", "barstacked", "step", "stepfilled".
             By default "step"
         **kwargs : kwargs
-            Keyword arguments passed to `PlotLineObject`
+            Keyword arguments passed to `puma.PlotLineObject`
 
         Raises
         ------
@@ -87,13 +87,6 @@ class Histogram(
         )
         # If flavour was specified, extract configuration from global config
         if self.flavour is not None:
-            if self.ratio_group is None:
-                self.ratio_group = self.flavour
-                logger.info(
-                    "Setting ratio group of histogram to %s. If this is not what "
-                    "you intended, specify the 'ratio_group' argument.",
-                    self.ratio_group,
-                )
             if self.flavour in global_config["flavour_categories"]:
                 # Use globally defined flavour colour if not specified
                 if self.colour is None:

--- a/puma/tests/test_histogram.py
+++ b/puma/tests/test_histogram.py
@@ -455,6 +455,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             Histogram(
                 rng.normal(3, 1, size=10_000),
                 flavour="bjets",
+                ratio_group="Ratio group 2",
                 label="(reference)",
             ),
             reference=True,
@@ -463,6 +464,7 @@ class histogram_plot_TestCase(unittest.TestCase):
             Histogram(
                 rng.normal(3.5, 1, size=10_000),
                 flavour="bjets",
+                ratio_group="Ratio group 2",
                 linestyle="--",
             ),
         )


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* The `ratio_group` property of `puma.Histogram` objects is no longer updated via the `flavour` argument. This is changed to avoid that users specify ratio_groups without knowing what they do.
* Removed `flavour` from the discriminant example plot

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
