### PR TITLE
Fix typo in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,4 +3,4 @@ FROM python:3.8-slim
 # Copy the current version of the repo in the image
 COPY . /puma_repo
 # Install and remove the folder afterwards
-RUN pip install ./puma_repo && rm -rf /puma_repo
+RUN pip install /puma_repo && rm -rf /puma_repo


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fixes a typo in the Dockerfile :
At some point we do a pip-install of `./puma_repo`, which is actually just working because the command is executed in the root directory. Using `/puma_repo` (without the dot) is cleaner
