### PR TITLE
Change labels of single-b jets and single-c jets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ### latest
-- support linestyles for var vs eff plots [#78](https://github.com/umami-hep/puma/pull/78)
+
+- Change default labels of `singlebjets` and `singlecjets` [#82](https://github.com/umami-hep/puma/pull/82)
+- Support linestyles for variable vs. efficiency plots [#78](https://github.com/umami-hep/puma/pull/78)
 
 ### [v0.1.3]
 

--- a/puma/utils/__init__.py
+++ b/puma/utils/__init__.py
@@ -139,7 +139,7 @@ global_config = {
         },
         "singlebjets": {
             "colour": "#1f77b4",  # blue (like b-jets)
-            "legend_label": "$b$-jets",
+            "legend_label": "single-$b$ jets",
         },
         "bbjets": {
             "colour": "#8E0024",  # dark red
@@ -147,7 +147,7 @@ global_config = {
         },
         "singlecjets": {
             "colour": "#ff7f0e",  # orange (like c-jets)
-            "legend_label": "$c$-jets",
+            "legend_label": "single-$c$ jets",
         },
         "ccjets": {
             "colour": "#ad4305",


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Changes the default labels of 
  * `singlebjets` (`"$b$-jets"` -> `"single-$b$ jets"`)
  * `singlecjets` (`"$c$-jets"` -> `"single-$c$ jets"`)


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/) (not affected)
