### PR TITLE
Improve `set_log()` method of `puma.PlotBase`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### latest
 
+- Splitting `force` argument of `set_log()` method into `force_x` and `force_y` [#83](https://github.com/umami-hep/puma/pull/83)
 - Adding `puma.PiePlot` class. Pie chart plots with `puma.HistogramPlot` are no longer possible [#70](https://github.com/umami-hep/puma/pull/70)
 - Change default labels of `singlebjets` and `singlecjets` [#82](https://github.com/umami-hep/puma/pull/82)
 - Support linestyles for variable vs. efficiency plots [#78](https://github.com/umami-hep/puma/pull/78)

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -404,17 +404,19 @@ class PlotBase(PlotObject):  # pylint: disable=too-many-instance-attributes
         """
         self.axis_top.set_title(self.title if title is None else title, **kwargs)
 
-    def set_log(self, force: bool = False):
+    def set_log(self, force_x: bool = False, force_y: bool = False):
         """Set log scale of the axes. For the y-axis, only the main panel is
         set. For the x-axes (also from the ratio subpanels), all are changed.
 
         Parameters
         ----------
-        force : bool, optional
-            Forcing log even if class variable is False, by default False
+        force_x : bool, optional
+            Forcing log on x-axis even if `logx` attribute is False, by default False
+        force_y : bool, optional
+            Forcing log on y-axis even if `logy` attribute is False, by default False
         """
 
-        if self.logx or force:
+        if self.logx or force_x:
             if not self.logx:
                 logger.warning(
                     "Setting log of x-axis but `logx` flag was set to False."
@@ -427,7 +429,7 @@ class PlotBase(PlotObject):  # pylint: disable=too-many-instance-attributes
             if self.axis_ratio_2:
                 self.axis_ratio_2.set_xscale("log")
 
-        if self.logy or force:
+        if self.logy or force_y:
             if not self.logy:
                 logger.warning(
                     "Setting log of y-axis but `logy` flag was set to False."


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* splits the `force` argument in `puma.PlotBase.set_log()` into `force_x` and `force_y`, which allows to force logscale on the axes separately

Relates to the following issues

* Closes #53 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/) (not affected)
