### PR TITLE
Fix that new tags trigger pypi publish

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - 'main'
+    tags:
+      - '*'
 
 jobs:
   unit_tests:


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* with the current setup, the publish to pypi job was not triggered when a tag was created. This should be fixed with this