### PR TITLE
Fix typo in example script

### DIFF
--- a/examples/plot_fraction_scan.py
+++ b/examples/plot_fraction_scan.py
@@ -101,4 +101,4 @@ frac_plot.xlabel = "$c$-jets efficiency"
 
 # Draw and save the plot
 frac_plot.draw()
-frac_plot.savefig("FractionPlot_test.png")
+frac_plot.savefig("FractionScanPlot_test.png")


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* fixes wrong filename in output of example script, which is used in the docs. Fixes this:
<img width="794" alt="image" src="https://user-images.githubusercontent.com/46069353/177330407-89ed6f5f-0114-4688-9110-c0d2e1ba945e.png">

