### PR TITLE
Adding `h5py` to Docker images

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,6 +1,14 @@
 name: Docker build
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
         
 env:
   GITLAB_CONTAINER_REGISTRY: gitlab-registry.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images
@@ -20,15 +28,21 @@ jobs:
       - name: Login to GitLab container registry
         run: docker login gitlab-registry.cern.ch -u ${{ secrets.GITLAB_USERNAME }} -p ${{ secrets.GITLAB_TOKEN }}
           
-      - name: Build and push slim image
-        run: |
-          docker build -f docker/Dockerfile --tag ${GITLAB_CONTAINER_REGISTRY}/puma:latest .
-          docker push ${GITLAB_CONTAINER_REGISTRY}/puma:latest
+      - name: Build slim image
+        run: docker build -f docker/Dockerfile --tag ${GITLAB_CONTAINER_REGISTRY}/puma:latest .
 
-      - name: Build and push dev image
-        run: |
-          docker build -f docker/Dockerfile_dev --tag ${GITLAB_CONTAINER_REGISTRY}/puma:latest-dev .
-          docker push ${GITLAB_CONTAINER_REGISTRY}/puma:latest-dev
+      # Push this image if this is on the main branch
+      - name: Push slim image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: docker push ${GITLAB_CONTAINER_REGISTRY}/puma:latest
+
+      - name: Build dev image
+        run: docker build -f docker/Dockerfile_dev --tag ${GITLAB_CONTAINER_REGISTRY}/puma:latest-dev .
+
+      # Push this image if this is on the main branch
+      - name: Push dev image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: docker push ${GITLAB_CONTAINER_REGISTRY}/puma:latest-dev
   
   build_release:
     # Build an extra image for tagged commits

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -16,7 +16,6 @@ env:
 jobs:
   build_latest:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     steps:
 
       - name: Checkout

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Adding `h5py` to the Docker images
 - Adding `transparent` attribute to `PlotObject` class. This allows to specify transparent background when initialising the plot [#96](https://github.com/umami-hep/puma/pull/96)
 
 ### [v0.1.5]

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Adding `h5py` to the Docker images
+- Adding `h5py` to the Docker images [#97](https://github.com/umami-hep/puma/pull/97)
 - Adding `transparent` attribute to `PlotObject` class. This allows to specify transparent background when initialising the plot [#96](https://github.com/umami-hep/puma/pull/96)
 
 ### [v0.1.5]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,3 +4,4 @@ FROM python:3.8-slim
 COPY . /puma_repo
 # Install and remove the folder afterwards
 RUN pip install /puma_repo && rm -rf /puma_repo
+RUN pip install h5py==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ coverage==6.3.1
 darglint==1.8.1
 flake8==4.0.1
 isort==5.10.1
+h5py==3.7.0
 librep==0.0.5
 matplotlib==3.5.1
 numpy==1.21.0


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* adds `h5py` to the Docker images. This might be useful for users who want to plot h5files 
* update pipeline such that Docker images are always built, just the push step requires to be on the `main` branch or on a tag. This way we ensure that the build will not fail after merging a PR

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/) (not affected)
