### PR TITLE
Update draw to support n_ratio_panels=0

### DIFF
--- a/puma/roc.py
+++ b/puma/roc.py
@@ -557,7 +557,8 @@ class RocPlot(PlotBase):  # pylint: disable=too-many-instance-attributes
             xmin if self.xmin is None else self.xmin,
             xmax if self.xmax is None else self.xmax,
         )
-        self.add_ratios()
+        if self.n_ratio_panels > 0:
+            self.add_ratios()
         self.set_title()
         self.set_log()
         self.set_y_lim()


### PR DESCRIPTION
Self-explanatory

Otherwise crashes with

`  File "/atlas/strebler/.local/lib/python3.9/site-packages/puma/roc.py", line 560, in draw
    self.add_ratios()
  File "/atlas/strebler/.local/lib/python3.9/site-packages/puma/roc.py", line 364, in add_ratios
    if len(self.reference_roc) != self.n_ratio_panels:`