### PR TITLE
Adding check and removal of nan values in histograms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Fix handling of nan values in histograms [#125](https://github.com/umami-hep/puma/pull/125)
 
 ### [v0.1.8] (2022/08/30)
 

--- a/puma/tests/utils/test_histogram_utils.py
+++ b/puma/tests/utils/test_histogram_utils.py
@@ -154,7 +154,7 @@ class hist_w_unc_TestCase(unittest.TestCase):
         np.testing.assert_array_almost_equal(unc_exp, unc)
 
     def test_inf_treatment(self):
-        """Test if the warning for number of inf values is raised in hist_w_unc"""
+        """Test if infinity values are treated as expected."""
 
         values_with_infs = np.array([1, 2, 3, -np.inf, +np.inf, +np.inf])
 

--- a/puma/tests/utils/test_histogram_utils.py
+++ b/puma/tests/utils/test_histogram_utils.py
@@ -6,6 +6,7 @@ Unit test script for the functions in utils/histogram.py
 import unittest
 
 import numpy as np
+from testfixtures import LogCapture
 
 from puma.utils import logger, set_log_level
 from puma.utils.histogram import hist_ratio, hist_w_unc, save_divide
@@ -151,6 +152,44 @@ class hist_w_unc_TestCase(unittest.TestCase):
         _, hist, unc, _ = hist_w_unc(values, weights=weights, bins=3, normed=False)
         np.testing.assert_array_almost_equal(hist_exp, hist)
         np.testing.assert_array_almost_equal(unc_exp, unc)
+
+    def test_inf_treatment(self):
+        """Test if the warning for number of inf values is raised in hist_w_unc"""
+
+        values_with_infs = np.array([1, 2, 3, -np.inf, +np.inf, +np.inf])
+
+        with self.subTest(
+            "Test if the warning for number of inf values is raised in hist_w_unc"
+        ):
+            with LogCapture("puma") as log:
+                _ = hist_w_unc(values_with_infs, bins=np.linspace(0, 3, 3))
+                log.check(
+                    (
+                        "puma",
+                        "WARNING",
+                        "Histogram values contain 3 +-inf values!",
+                    )
+                )
+        with self.subTest(
+            "Test if error is raised if inf values are in input but no range is defined"
+        ):
+            with self.assertRaises(ValueError):
+                hist_w_unc(values_with_infs, bins=10)
+
+    def test_nan_check(self):
+        """Test if the warning with number of nan values is raised in hist_w_unc"""
+
+        values_with_nans = np.array([1, 2, 3, np.nan, np.nan])
+
+        with LogCapture("puma") as log:
+            _ = hist_w_unc(values_with_nans, bins=4)
+            log.check(
+                (
+                    "puma",
+                    "WARNING",
+                    "Histogram values contain 2 nan values!",
+                )
+            )
 
     # TODO: Add unit tests for hist_ratio
 

--- a/puma/utils/histogram.py
+++ b/puma/utils/histogram.py
@@ -105,6 +105,11 @@ def hist_w_unc(
         arr = arr[~nan_mask]
         weights = weights[~nan_mask]
 
+    # Check if there are inf values in the input values
+    inf_mask = np.isinf(arr)
+    if np.sum(inf_mask) > 0:
+        logger.warning("Histogram values contain %i +-inf values!", np.sum(inf_mask))
+
     # Calculate the counts and the bin edges
     counts, bin_edges = np.histogram(arr, bins=bins, range=bins_range, weights=weights)
 

--- a/puma/utils/histogram.py
+++ b/puma/utils/histogram.py
@@ -1,6 +1,8 @@
 """Helper function for histogram handling."""
 import numpy as np
 
+from puma.utils import logger
+
 
 def save_divide(
     numerator,
@@ -94,6 +96,14 @@ def hist_w_unc(
     """
     if weights is None:
         weights = np.ones(len(arr))
+
+    # Check if there are nan values in the input values
+    nan_mask = np.isnan(arr)
+    if np.sum(nan_mask) > 0:
+        logger.warning("Histogram values contain %i nan values!", np.sum(nan_mask))
+        # Remove nan values
+        arr = arr[~nan_mask]
+        weights = weights[~nan_mask]
 
     # Calculate the counts and the bin edges
     counts, bin_edges = np.histogram(arr, bins=bins, range=bins_range, weights=weights)


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fixes the histogram calculation when nan values are included in the histogram data
* Raises a logger warning with the number of nan (and +- infinity) values if there are any:
```bash
$ python examples/plot_basic_histogram.py 
WARNING:puma: Histogram values contain 2 nan values!
WARNING:puma: Histogram values contain 1 +-inf values!
```

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] ~~[Documentation](https://umami-hep.github.io/puma/)~~
