### PR TITLE
Adding boosted categories for Xbb to utils

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### [Latest]
+
+- Adding boosted categories for Xbb to utils [!138](https://github.com/umami-hep/puma/pull/138)
 - Running pylint also for tests [#133](https://github.com/umami-hep/puma/pull/133)
 - Fix handling of nan values in histograms [#125](https://github.com/umami-hep/puma/pull/125)
 - Adding support for under- and overflow bins in `puma.HistogramPlot` [#124](https://github.com/umami-hep/puma/pull/124)

--- a/puma/utils/__init__.py
+++ b/puma/utils/__init__.py
@@ -276,6 +276,22 @@ global_config = {
             "colour": "#e76f51",
             "legend_label": "\u03C4's in $b$- or $c$-hadron decay",
         },
+        "Hbb": {
+            "colour": "#1f77b4",  # blue
+            "legend_label": "$Hbb$-jets",
+        },
+        "Hcc": {
+            "colour": "#B45F06",  # Tenne (dark orange)
+            "legend_label": "$Hcc$-jets",
+        },
+        "top": {
+            "colour": "#A300A3",  # dark magenta
+            "legend_label": "$Top$-jets",
+        },
+        "dijets": {
+            "colour": "#38761D",  # Bilbao (dark green)
+            "legend_label": "light-dijets",
+        },
     },
     "hist_err_style": {
         "fill": False,


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Adding boosted jet categories to the utils (label, colour) for Xbb

Relates to the following issues

* Closes #137 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
