### PR TITLE
Replace dijets category with QCD catergory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Replace `dijets` category with `QCD` category [!170](https://github.com/umami-hep/puma/pull/170)
+
 ### [v0.2.3] (2023/03/28)
 
 - Integrate [atlas-ftag-tools](https://github.com/umami-hep/atlas-ftag-tools/) package [!168](https://github.com/umami-hep/puma/pull/168)

--- a/puma/utils/__init__.py
+++ b/puma/utils/__init__.py
@@ -290,7 +290,7 @@ global_config = {
             "colour": "#A300A3",  # dark magenta
             "legend_label": "$Top$-jets",
         },
-        "dijets": {
+        "QCD": {
             "colour": "#38761D",  # Bilbao (dark green)
             "legend_label": "QCD-jets",
         },


### PR DESCRIPTION
## Summary

This pull request introduces the following changes.

* `dijets` category was replaced with the `QCD` category in the `flavour_categories`

Relates to the following issues

* #167 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] ~~[Documentation](https://umami-hep.github.io/puma/)~~
