### PR TITLE
Add all requirements to docker image

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -3,13 +3,13 @@ name: Docker build
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'main'
+      - "main"
     tags:
-      - '*'
-        
+      - "*"
+
 env:
   GITLAB_CONTAINER_REGISTRY: gitlab-registry.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images
 
@@ -17,42 +17,32 @@ jobs:
   build_latest:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@master
-          
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build slim image
+      - name: Build image
         run: docker build -f docker/Dockerfile --tag ${GITLAB_CONTAINER_REGISTRY}/puma:latest .
-
-      - name: Build dev image
-        run: docker build -f docker/Dockerfile_dev --tag ${GITLAB_CONTAINER_REGISTRY}/puma:latest-dev .
 
       - name: Login to GitLab container registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: docker login gitlab-registry.cern.ch -u ${{ secrets.GITLAB_USERNAME }} -p ${{ secrets.GITLAB_TOKEN }}
-          
+
       # Push this image if this is on the main branch
-      - name: Push slim image
+      - name: Push image
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: docker push ${GITLAB_CONTAINER_REGISTRY}/puma:latest
 
-      # Push this image if this is on the main branch
-      - name: Push dev image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: docker push ${GITLAB_CONTAINER_REGISTRY}/puma:latest-dev
-  
   build_release:
     # Build an extra image for tagged commits
     runs-on: ubuntu-latest
     if: startsWith(github.event.ref, 'refs/tags')
     steps:
-
       - name: Checkout
         uses: actions/checkout@master
-          
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/README.md
+++ b/README.md
@@ -65,17 +65,4 @@ On a machine/cluster with singularity installed:
 singularity shell -B $PWD docker://gitlab-registry.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images/puma:latest
 ```
 
-### Extended image for development
-
-_For development, just replace the tag of the image_:
-
-`latest` -> `latest-dev`
-
-In addition to the minimal requirements that are required to use `puma`, the
-`puma:latest-dev` image has the `requirements.txt` from the `puma` repo installed as
-well.
-This means that packages like `pytest`, `black`, `pylint`, etc. are installed as well.
-However, note that `puma` itself is not installed in that image such that the dev-version
-on your machine can be used/tested.
-
 **The images are automatically updated via GitHub and pushed to this [repository registry](https://gitlab.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images/container_registry).**

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Remove dev image [!176](https://github.com/umami-hep/puma/pull/176)
 - Fix bug in ratio axis limits [!175](https://github.com/umami-hep/puma/pull/175)
 - Add `VarVsVar` plot [!172](https://github.com/umami-hep/puma/pull/172)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,13 @@
 FROM python:3.8.15-slim
 
+RUN apt update && apt install -y vim
+
+# install requirements that are needed for development
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
 # Copy the current version of the repo in the image
 COPY . /puma_repo
+
 # Install and remove the folder afterwards
 RUN pip install /puma_repo && rm -rf /puma_repo
-RUN pip install h5py==3.8.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,12 @@
-FROM python:3.8.15-slim
+FROM python:3.8.15
 
 RUN apt update && apt install -y vim
 
 # install requirements that are needed for development
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN python -m pip install -r requirements.txt
 
-# Copy the current version of the repo in the image
-COPY . /puma_repo
+# copy and install package
+COPY . .
+RUN python -m pip install -e .
 
-# Install and remove the folder afterwards
-RUN pip install /puma_repo && rm -rf /puma_repo

--- a/docker/Dockerfile_dev
+++ b/docker/Dockerfile_dev
@@ -1,7 +1,0 @@
-FROM python:3.8.15
-
-RUN apt update && apt install -y vim
-
-# install requirements that are needed for development
-COPY requirements.txt .
-RUN pip install -r requirements.txt

--- a/docs/source/dev_guidelines/docker.md
+++ b/docs/source/dev_guidelines/docker.md
@@ -5,25 +5,14 @@ The Docker images are built on GitHub and contain the latest version from the `m
 The container registry with all available tags can be found
 [here](https://gitlab.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images/container_registry/13727).
 
-## Extended image for development
-
-_For development, you should use the `latest-dev` tagged image_:
-
-In addition to the minimal requirements that are required to use `puma`, the
-`puma:latest-dev` image has the `requirements.txt` from the `puma` repo installed as
-well.
-This means that packages like `pytest`, `black`, `pylint`, etc. are installed as well.
-However, note that `puma` itself is not installed in that image such that the dev-version
-on your machine can be used/tested.
-
 On a machine with Docker installed:
 
 ```bash
-docker run -it --rm -v $PWD:/puma_container -w /puma_container gitlab-registry.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images/puma:latest-dev bash
+docker run -it --rm -v $PWD:/puma_container -w /puma_container gitlab-registry.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images/puma:latest bash
 ```
 
 On a machine/cluster with singularity installed:
 
 ```bash
-singularity shell -B $PWD docker://gitlab-registry.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images/puma:latest-dev
+singularity shell -B $PWD docker://gitlab-registry.cern.ch/atlas-flavor-tagging-tools/training-images/puma-images/puma:latest
 ```


### PR DESCRIPTION
## Summary

For some reason, the main docker image only installed `h5py`, which created problems as reported by @mtanasin. I am adding all the requirements here. We should think about removing the dev image as I don't really see the point of it... having a singe image with all the deps and an editable install would be much cleaner.

Thoughts @dkobylianskii @afroch @philippgadow?

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
