### PR TITLE
Adding Fraction Scans to high level API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Adding fraction scans to high level API [!178](https://github.com/umami-hep/puma/pull/178)
 - Update pre-commit (using ruff) and store tagger scores as structured array [!177](https://github.com/umami-hep/puma/pull/177)
 - Remove dev image [!176](https://github.com/umami-hep/puma/pull/176)
 - Fix bug in ratio axis limits [!175](https://github.com/umami-hep/puma/pull/175)

--- a/docs/source/examples/high_level_api.md
+++ b/docs/source/examples/high_level_api.md
@@ -27,7 +27,7 @@ here for the _b_-jet discriminant
 §§§examples/high_level_plots.py:50:52§§§
 ```
 
-<img src=https://github.com/umami-hep/puma/raw/examples-material/hlplots_disc_b.png width=500>
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_disc.png width=500>
 
 
 ## ROC plots
@@ -36,27 +36,38 @@ In the same manner you can plot ROC curves, here for the _b_-tagging performance
 ```py
 §§§examples/high_level_plots.py:54:56§§§
 ```
-<img src=https://github.com/umami-hep/puma/raw/examples-material/hlplots_roc_b.png width=500>
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_roc.png width=500>
 
 
 
 ## Performance vs a variable
 In this case we plot the performance as a function of the jet pT with the same syntax as above for an inclusive working point of 70%
 ```py
-§§§examples/high_level_plots.py:59:72§§§
+§§§examples/high_level_plots.py:59:71§§§
 ```
-<img src=https://github.com/umami-hep/puma/raw/examples-material/hlplots_dummy_tagger_pt_bjets_eff.png width=500>
-<img src=https://github.com/umami-hep/puma/raw/examples-material/hlplots_dummy_tagger_pt_cjets_rej.png width=500>
-<img src=https://github.com/umami-hep/puma/raw/examples-material/hlplots_dummy_tagger_pt_ujets_rej.png width=500>
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_profile_fixed_bjets_eff.png width=500>
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_profile_fixed_cjets_rej.png width=500>
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_profile_fixed_ujets_rej.png width=500>
 
 and similar for a fixed b-efficiency per bin.
 ```py
-§§§examples/high_level_plots.py:74:84§§§
+§§§examples/high_level_plots.py:73:82§§§
 ```
 
-<img src=https://github.com/umami-hep/puma/raw/examples-material/hlplots_dummy_tagger_fixed_per_bin_pt_bjets_eff.png width=500>
-<img src=https://github.com/umami-hep/puma/raw/examples-material/hlplots_dummy_tagger_fixed_per_bin_pt_cjets_rej.png width=500>
-<img src=https://github.com/umami-hep/puma/raw/examples-material/hlplots_dummy_tagger_fixed_per_bin_pt_ujets_rej.png width=500>
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_profile_flat_bjets_eff.png width=500>
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_profile_flat_cjets_rej.png width=500>
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_profile_flat_ujets_rej.png width=500>
 
 
 Similar to above you can also do these plots for _c_-tagging by changing the `signal_class` to `cjets`.
+
+
+## Fraction scans
+
+Plot the two background efficiencies as a function of the $f_c$ or $f_b$ value.
+
+```py
+§§§examples/high_level_plots.py:84:87§§§
+```
+
+<img src=https://github.com/umami-hep/puma/raw/examples-material/dummy_bjets_fraction_scan.png width=500>

--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -31,7 +31,7 @@ rnnip = Tagger(
 # create the Results object
 # for c-tagging use signal="cjets"
 # for Xbb/cc-tagging use signal="hbb"/"hcc"
-results = Results(signal="bjets")
+results = Results(signal="bjets", sample="dummy")
 
 # load taggers from the file object
 logger.info("Loading taggers.")
@@ -49,11 +49,11 @@ results.atlas_second_tag = (
 
 # tagger discriminant plots
 logger.info("Plotting tagger discriminant plots.")
-results.plot_discs("hlplots_disc_b.png")
+results.plot_discs()
 
 # ROC curves
 logger.info("Plotting ROC curves.")
-results.plot_rocs("hlplots_roc_b.png")
+results.plot_rocs()
 
 
 logger.info("Plotting efficiency/rejection vs pT curves.")
@@ -65,7 +65,6 @@ results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$\n70% WP
 # or alternatively also pass the argument `working_point` to the plot_var_perf function.
 # to specify the `disc_cut` per tagger is also possible.
 results.plot_var_perf(
-    plot_name="hlplots_dummy_tagger_pt",
     working_point=0.7,
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
     fixed_eff_bin=False,
@@ -75,7 +74,6 @@ results.atlas_second_tag = (
     "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$\n70% WP per bin"
 )
 results.plot_var_perf(
-    plot_name="hlplots_dummy_tagger_pt_fixed_per_bin",
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
     fixed_eff_bin=True,
     working_point=0.7,

--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -80,3 +80,8 @@ results.plot_var_perf(
     h_line=0.7,
     disc_cut=None,
 )
+
+# fraction scan plots
+logger.info("Plotting fraction scans.")
+results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$\n70% WP"
+results.plot_fraction_scans(efficiency=0.7, rej=False)

--- a/puma/fraction_scan.py
+++ b/puma/fraction_scan.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+def get_fx_values(num=100):
+    return np.concatenate(
+        (np.logspace(-3, -1, num // 2), np.linspace(0.1, 1.0, num // 2))
+    )
+
+
+def get_efficiency(scores, fx):
+    return np.sum(scores > fx) / len(scores)

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -213,7 +213,7 @@ class Results:
         for tagger in self.taggers.values():
             if exclude_tagger is not None and tagger.name in exclude_tagger:
                 continue
-            discs = tagger.get_disc(self.signal)
+            discs = tagger.discriminant(self.signal)
             for flav in self.flavours:
                 tagger_output_plot.add(
                     Histogram(
@@ -263,7 +263,7 @@ class Results:
         plot_roc = RocPlot(**roc_plot_args)
 
         for tagger in self.taggers.values():
-            discs = tagger.get_disc(self.signal)
+            discs = tagger.discriminant(self.signal)
             for background in self.backgrounds:
                 rej = calc_rej(
                     discs[tagger.is_flav(self.signal)],
@@ -348,7 +348,7 @@ class Results:
             if not working_point_in_kwargs:
                 kwargs["working_point"] = tagger.working_point
 
-            discs = tagger.get_disc(self.signal)
+            discs = tagger.discriminant(self.signal)
             is_signal = tagger.is_flav(self.signal)
             plot_sig_eff.add(
                 VarVsEff(

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 """Unit test script for the functions in hlplots/tagger.py."""
+
 import tempfile
 import unittest
 from pathlib import Path
 
 import h5py
 import numpy as np
+from ftag import get_mock_file
 
 from puma.hlplots import Results
 from puma.hlplots.tagger import Tagger
 from puma.utils import (
     get_dummy_2_taggers,
-    get_dummy_multiclass_scores,
     logger,
     set_log_level,
 )
@@ -74,12 +75,13 @@ class ResultsPlotsTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up for unit tests."""
-        scores, labels = get_dummy_multiclass_scores()
-        dummy_tagger_1 = Tagger("dummy")
+        f = get_mock_file()[1]
+        dummy_tagger_1 = Tagger("MockTagger")
         dummy_tagger_1.labels = np.array(
-            labels, dtype=[("HadronConeExclTruthLabelID", "i4")]
+            f["jets"]["HadronConeExclTruthLabelID"],
+            dtype=[("HadronConeExclTruthLabelID", "i4")],
         )
-        dummy_tagger_1.scores = scores
+        dummy_tagger_1.scores = f["jets"]
         dummy_tagger_1.label = "dummy tagger"
         self.dummy_tagger_1 = dummy_tagger_1
 

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -11,11 +11,7 @@ from ftag import get_mock_file
 
 from puma.hlplots import Results
 from puma.hlplots.tagger import Tagger
-from puma.utils import (
-    get_dummy_2_taggers,
-    logger,
-    set_log_level,
-)
+from puma.utils import get_dummy_2_taggers, logger, set_log_level
 
 set_log_level(logger, "DEBUG")
 
@@ -182,3 +178,33 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results.add(self.dummy_tagger_1)
             results.plot_discs()
             self.assertIsFile(results.get_filename("disc"))
+
+    def test_plot_fraction_scans_hbb_error(self):
+        """Test that correct error is raised."""
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.f_c = 0.05
+        with tempfile.TemporaryDirectory() as tmp_file:
+            results = Results(signal="hbb", sample="test", output_dir=tmp_file)
+            results.add(self.dummy_tagger_1)
+            with self.assertRaises(ValueError):
+                results.plot_fraction_scans(rej=False)
+
+    def test_plot_fraction_scans_bjets_eff(self):
+        """Test that png file is being created."""
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.f_c = 0.05
+        with tempfile.TemporaryDirectory() as tmp_file:
+            results = Results(signal="bjets", sample="test", output_dir=tmp_file)
+            results.add(self.dummy_tagger_1)
+            results.plot_fraction_scans(rej=False)
+            self.assertIsFile(results.get_filename("fraction_scan"))
+
+    def test_plot_fraction_scans_cjets_rej(self):
+        """Test that png file is being created."""
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.f_b = 0.05
+        with tempfile.TemporaryDirectory() as tmp_file:
+            results = Results(signal="cjets", sample="test", output_dir=tmp_file)
+            results.add(self.dummy_tagger_1)
+            results.plot_fraction_scans(rej=True)
+            self.assertIsFile(results.get_filename("fraction_scan"))

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -5,13 +5,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import h5py
 import numpy as np
 from ftag import get_mock_file
 
 from puma.hlplots import Results
 from puma.hlplots.tagger import Tagger
-from puma.utils import get_dummy_2_taggers, logger, set_log_level
+from puma.utils import logger, set_log_level
 
 set_log_level(logger, "DEBUG")
 
@@ -52,17 +51,12 @@ class ResultsTestCase(unittest.TestCase):
 
     def test_add_taggers_from_file(self):
         """Test for Results.add_taggers_from_file function."""
-        tmp_dir = tempfile.TemporaryDirectory()  # pylint: disable=R1732
-        rng = np.random.default_rng(seed=16)
-        with h5py.File(f"{tmp_dir.name}/test.h5", "w") as file:
-            data = get_dummy_2_taggers()
-            data["pt"] = rng.random(len(data))
-            file.create_dataset("jets", data=data.to_records())
+        tempfile.TemporaryDirectory()  # pylint: disable=R1732
+        np.random.default_rng(seed=16)
+        fname = get_mock_file()[0]
         results = Results(signal="bjets", sample="test")
-        taggers = [Tagger("rnnip")]
-        results.add_taggers_from_file(
-            taggers, f"{tmp_dir.name}/test.h5", perf_var=data["pt"]
-        )
+        taggers = [Tagger("MockTagger")]
+        results.add_taggers_from_file(taggers, fname)
         self.assertEqual(list(results.taggers.values()), taggers)
 
 

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -160,7 +160,7 @@ class TaggerTestCase(unittest.TestCase):
         discs = tagger.discriminant("bjets")
         np.testing.assert_array_equal(discs, np.zeros(10))
 
-    def testdisc_c_calc_no_fb(self):
+    def test_disc_c_calc_no_fb(self):
         """Test c-disc calculation w/o f_c provided."""
         tagger = Tagger("dummy")
         tagger.scores = self.scores

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -128,7 +128,8 @@ class TaggerTestCase(unittest.TestCase):
         """Set up for tests."""
         scores = np.column_stack((np.ones(10), np.ones(10), np.ones(10)))
         self.scores = u2s(
-            scores, dtype=[("ujets", "f4"), ("cjets", "f4"), ("bjets", "f4")]
+            scores,
+            dtype=[("dummy_pu", "f4"), ("dummy_pc", "f4"), ("dummy_pb", "f4")],
         )
 
     def test_disc_cut_template(self):
@@ -140,32 +141,29 @@ class TaggerTestCase(unittest.TestCase):
     def test_disc_b_calc_no_fc(self):
         """Test b-disc calculation w/o f_c provided."""
         tagger = Tagger("dummy")
+        print(self.scores)
         tagger.scores = self.scores
-
-        with self.assertRaises(ValueError):
-            tagger.calc_disc_b()
+        with self.assertRaises(TypeError):
+            tagger.discriminant("bjets")
 
     def test_disc_b_calc(self):
         """Test b-disc calculation."""
-        tagger = Tagger("dummy")
+        tagger = Tagger("dummy", f_c=0.5)
         tagger.scores = self.scores
-        tagger.f_c = 0.5
-        discs = tagger.calc_disc_b()
-
+        discs = tagger.discriminant("bjets")
         np.testing.assert_array_equal(discs, np.zeros(10))
 
-    def test_sig_b_calc_no_fb(self):
+    def testdisc_c_calc_no_fb(self):
         """Test c-disc calculation w/o f_c provided."""
         tagger = Tagger("dummy")
         tagger.scores = self.scores
-        with self.assertRaises(ValueError):
-            tagger.calc_disc_c()
+        with self.assertRaises(TypeError):
+            tagger.discriminant("cjets")
 
-    def test_sig_b_calc(self):
+    def test_disc_c_calc(self):
         """Test c-disc calculation."""
-        tagger = Tagger("dummy")
+        tagger = Tagger("dummy", f_b=0.5)
         tagger.scores = self.scores
-        tagger.f_b = 0.5
-        discs = tagger.calc_disc_c()
+        discs = tagger.discriminant("cjets")
 
         np.testing.assert_array_equal(discs, np.zeros(10))

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -138,10 +138,17 @@ class TaggerTestCase(unittest.TestCase):
         tagger = Tagger("dummy", **template_disc_cut)
         self.assertEqual(tagger.disc_cut, 1.5)
 
+    def test_errors(self):
+        tagger = Tagger("dummy")
+        tagger.scores = self.scores
+        with self.assertRaises(ValueError):
+            tagger.discriminant("hbb", fx=0.1)
+        with self.assertRaises(ValueError):
+            tagger.discriminant("ujets")
+
     def test_disc_b_calc_no_fc(self):
         """Test b-disc calculation w/o f_c provided."""
         tagger = Tagger("dummy")
-        print(self.scores)
         tagger.scores = self.scores
         with self.assertRaises(TypeError):
             tagger.discriminant("bjets")

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ scipy==1.10.1
 tables==3.7.0
 testfixtures==7.0.0
 palettable==3.3.0
-atlas-ftag-tools==0.0.5
+atlas-ftag-tools==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ scipy==1.10.1
 tables==3.7.0
 testfixtures==7.0.0
 palettable==3.3.0
-atlas-ftag-tools==0.1.0
+atlas-ftag-tools==0.1.1


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Add the fraction scan plots to the high level API
* `Tagger` now uses https://github.com/umami-hep/atlas-ftag-tools/ to compute discriminants
* Output filenames are set automatically in the HLAPI

Relates to the following issues

* https://github.com/umami-hep/puma/issues/140

Todo:
- [x] tests

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
