### PR TITLE
Fixing issue in use_atlas_tag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,8 @@
 
 ### [Latest]
 
+- Fixing issue in use_atlas_tag [!184](https://github.com/umami-hep/puma/pull/184)
 - Add probability plots to HLAPI and support WP vlines [!183](https://github.com/umami-hep/puma/pull/183)
-
 
 ### [v0.2.5] (2023/05/12)
 

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -587,9 +587,6 @@ class PlotBase(PlotObject):
 
         Parameters
         ----------
-        use_tag : bool, optional
-            If False, ATLAS style will be applied but no tag will be put on the plot.
-            If True, the tag will be put on as well, by default True
         force : bool, optional
             Force ATLAS style also if class variable is False, by default False
         """

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -582,7 +582,7 @@ class PlotBase(PlotObject):
             **kwargs,
         )
 
-    def atlasify(self, use_tag: bool = True, force: bool = False):
+    def atlasify(self, force: bool = False):
         """Apply ATLAS style to all axes using the atlasify package.
 
         Parameters
@@ -603,7 +603,7 @@ class PlotBase(PlotObject):
 
         if self.apply_atlas_style or force:
             logger.debug("Initialise ATLAS style using atlasify.")
-            if use_tag is True:
+            if self.use_atlas_tag is True:
                 # TODO: for some reason, pylint complains about the used arguments
                 # when calling atlasify ("unexpected-keyword-arg") error
                 # --> fix this

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -562,7 +562,7 @@ class RocPlot(PlotBase):
 
         self.plotting_done = True
         if self.apply_atlas_style is True:
-            self.atlasify(use_tag=self.use_atlas_tag)
+            self.atlasify()
             # atlasify can only handle one legend. Therefore, we remove the frame of
             # the second legend by hand
             if self.legend_flavs is not None:

--- a/puma/var_vs_var.py
+++ b/puma/var_vs_var.py
@@ -411,4 +411,4 @@ class VarVsVarPlot(PlotBase):
         self.make_legend(plt_handles, ax_mpl=self.axis_top)
         self.plotting_done = True
         if self.apply_atlas_style is True:
-            self.atlasify(use_tag=self.use_atlas_tag)
+            self.atlasify()


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* FIxing an issue in the `plot_base`. If `apply_atlas_style` is true, but the `use_atlas_tag` is false, the ATLAS tag will be plotted because the argument is not correctly passed. Is fixed by passing directly the `self.use_atlas_tag` option instead of an extra command.

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
