### PR TITLE
numpy 1.21 u2s can't convert dtype

### DIFF
--- a/puma/utils/generate.py
+++ b/puma/utils/generate.py
@@ -46,7 +46,7 @@ def get_dummy_multiclass_scores(
         rng.normal(loc=[0, 0, bjets_mean], scale=2, size=(size_class, 3)), axis=1
     )
     output = np.concatenate((ujets, cjets, bjets))
-    output = u2s(output, dtype=[("ujets", "f4"), ("cjets", "f4"), ("bjets", "f4")])
+    output = u2s(output, dtype=np.dtype([("ujets", "f4"), ("cjets", "f4"), ("bjets", "f4")]))
     labels = np.concatenate(
         (np.zeros(size_class), np.ones(size_class) * 4, np.ones(size_class) * 5)
     )

--- a/puma/utils/generate.py
+++ b/puma/utils/generate.py
@@ -46,7 +46,9 @@ def get_dummy_multiclass_scores(
         rng.normal(loc=[0, 0, bjets_mean], scale=2, size=(size_class, 3)), axis=1
     )
     output = np.concatenate((ujets, cjets, bjets))
-    output = u2s(output, dtype=np.dtype([("ujets", "f4"), ("cjets", "f4"), ("bjets", "f4")]))
+    output = u2s(
+        output, dtype=np.dtype([("ujets", "f4"), ("cjets", "f4"), ("bjets", "f4")])
+    )
     labels = np.concatenate(
         (np.zeros(size_class), np.ones(size_class) * 4, np.ones(size_class) * 5)
     )


### PR DESCRIPTION
To support a slightly older version of numpy (which comes with the latest athena 23.0, LCG 102) u2s should be provided an np.dtype.
It's this same issue: https://github.com/numpy/numpy/issues/22428