### PR TITLE
Support for older versions of matplotlib.Figure

### DIFF
--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -319,7 +319,7 @@ class PlotBase(PlotObject):
             ratio_height = 1.2
             height = top_height + self.n_ratio_panels * ratio_height
             figsize = (width, height) if self.figsize is None else self.figsize
-            self.fig = Figure(figsize=figsize, layout="constrained")
+            self.fig = Figure(figsize=figsize, constrained_layout=True)
 
             if self.n_ratio_panels == 0:
                 self.axis_top = self.fig.gca()


### PR DESCRIPTION
Setting the layout in Figure to constrained can be done in multiple ways. The version of matplotlib bundled with LCG 102 / current athena 23.0 is 3.3.something, and only supports the `constrained_layout=True` way, not `layout="constrained"`. Together with PR #198 this change makes puma fully compatible with latest numpy and matplotlib, and the versions currently pulled in with `asetup Athena,23.0`.