### PR TITLE
add support to set a per ROC reference for the ratios

### DIFF
--- a/puma/roc.py
+++ b/puma/roc.py
@@ -235,7 +235,8 @@ class RocPlot(PlotBase):
         reference : bool, optional
             If roc is used as reference for ratio calculation, by default False
         reference_key : str, optional
-            Identifier of the reference ROC curve for ratio calculation if the rejection class has no class-wide reference, by default None
+            Identifier of the reference ROC curve for ratio calculation if
+			the rejection class has no class-wide reference, by default None
 
         Raises
         ------

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -23,6 +23,7 @@ class Roc(PlotLineObject):
         rej_class: str | Flavour = None,
         signal_class: str = None,
         key: str = None,
+        reference_roc_key: str = None,
         **kwargs,
     ) -> None:
         """Initialise properties of roc curve object.
@@ -65,6 +66,7 @@ class Roc(PlotLineObject):
             Flavours[rej_class] if isinstance(rej_class, str) else rej_class
         )
         self.key = key
+        self.reference_roc_key = reference_roc_key
 
     def binomial_error(self, norm: bool = False, n_test: int = None) -> np.ndarray:
         """Calculate binomial error of roc curve.
@@ -215,7 +217,7 @@ class RocPlot(PlotBase):
         self.legend_flavs = None
         self.leg_rej_loc = "lower left"
 
-    def add_roc(self, roc_curve: object, key: str = None, reference: bool = False):
+    def add_roc(self, roc_curve: object, key: str = None, reference: bool = False, reference_key: str = None):
         """Adding puma.Roc object to figure.
 
         Parameters
@@ -289,6 +291,12 @@ class RocPlot(PlotBase):
             )
             self.set_roc_reference(key, roc_curve.rej_class)
 
+        if reference_key:
+            logger.debug(
+                "Setting roc %s as reference for %s", reference_key, key
+            )
+            roc_curve.reference_roc_key = reference_key
+
     def set_roc_reference(self, key: str, rej_class: Flavour):
         """Setting the reference roc curves used in the ratios.
 
@@ -359,7 +367,7 @@ class RocPlot(PlotBase):
         ValueError
             If no ratio classes are set
         """
-        if len(self.reference_roc) != self.n_ratio_panels:
+        if self.reference_roc and len(self.reference_roc) != self.n_ratio_panels:
             raise ValueError(
                 f"{len(self.reference_roc)} reference rocs defined but requested "
                 f"{self.n_ratio_panels} ratio panels."
@@ -399,9 +407,18 @@ class RocPlot(PlotBase):
         for key, elem in self.rocs.items():
             if elem.rej_class != rej_class:
                 continue
-            ratio_sig_eff, ratio, ratio_err = elem.divide(
-                self.rocs[self.reference_roc[rej_class]]
-            )
+            if self.reference_roc:
+                ratio_sig_eff, ratio, ratio_err = elem.divide(
+                    self.rocs[self.reference_roc[rej_class]]
+                )
+            elif elem.reference_roc_key:
+                ratio_sig_eff, ratio, ratio_err = elem.divide(
+                    self.rocs[elem.reference_roc_key]
+                )
+            else:
+                ratio_sig_eff, ratio, ratio_err = elem.divide(
+                    elem
+                )
             self.roc_ratios[key] = (ratio_sig_eff, ratio, ratio_err)
             axis.plot(
                 ratio_sig_eff,

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -217,7 +217,13 @@ class RocPlot(PlotBase):
         self.legend_flavs = None
         self.leg_rej_loc = "lower left"
 
-    def add_roc(self, roc_curve: object, key: str = None, reference: bool = False, reference_key: str = None):
+    def add_roc(
+        self,
+        roc_curve: object,
+        key: str = None,
+        reference: bool = False,
+        reference_key: str = None
+    ):
         """Adding puma.Roc object to figure.
 
         Parameters
@@ -292,9 +298,7 @@ class RocPlot(PlotBase):
             self.set_roc_reference(key, roc_curve.rej_class)
 
         if reference_key:
-            logger.debug(
-                "Setting roc %s as reference for %s", reference_key, key
-            )
+            logger.debug("Setting roc %s as reference for %s", reference_key, key)
             roc_curve.reference_roc_key = reference_key
 
     def set_roc_reference(self, key: str, rej_class: Flavour):
@@ -407,6 +411,7 @@ class RocPlot(PlotBase):
         for key, elem in self.rocs.items():
             if elem.rej_class != rej_class:
                 continue
+
             if self.reference_roc:
                 ratio_sig_eff, ratio, ratio_err = elem.divide(
                     self.rocs[self.reference_roc[rej_class]]
@@ -416,9 +421,8 @@ class RocPlot(PlotBase):
                     self.rocs[elem.reference_roc_key]
                 )
             else:
-                ratio_sig_eff, ratio, ratio_err = elem.divide(
-                    elem
-                )
+                ratio_sig_eff, ratio, ratio_err = elem.divide(elem)
+
             self.roc_ratios[key] = (ratio_sig_eff, ratio, ratio_err)
             axis.plot(
                 ratio_sig_eff,

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -236,7 +236,7 @@ class RocPlot(PlotBase):
             If roc is used as reference for ratio calculation, by default False
         reference_key : str, optional
             Identifier of the reference ROC curve for ratio calculation if
-			the rejection class has no class-wide reference, by default None
+            the rejection class has no class-wide reference, by default None
 
         Raises
         ------

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -234,6 +234,8 @@ class RocPlot(PlotBase):
             Unique identifier for roc_curve, by default None
         reference : bool, optional
             If roc is used as reference for ratio calculation, by default False
+        reference_key : str, optional
+            Identifier of the reference ROC curve for ratio calculation if the rejection class has no class-wide reference, by default None
 
         Raises
         ------

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -222,7 +222,7 @@ class RocPlot(PlotBase):
         roc_curve: object,
         key: str = None,
         reference: bool = False,
-        reference_key: str = None
+        reference_key: str = None,
     ):
         """Adding puma.Roc object to figure.
 


### PR DESCRIPTION
This change adds support to set a per curve reference to the ROC curves, besides a reference per reject class. This allows to make ROC curve comparisons between datasets, for example between two validation rounds:

This adds a parameter `reference_key` to `add_roc()`, so something like the following can be done:
```python
plot_roc = RocPlot(
    n_ratio_panels=1,
    ylabel="Background rejection",
    xlabel="$b$-jet efficiency",
    atlas_second_tag="$\\sqrt{s}=13$ TeV, EMTopo jets \n29th - 30th validation round ttbar, $f_{c}=0.018$",
    figsize=(6.5, 6),
    y_scale=1.4,
)
plot_roc.add_roc(
    Roc(
        sig_eff,
        fastGN1_ujets_rej_r29,
        n_test=n_jets_light_r29,
        rej_class="ujets",
        signal_class="bjets",
        label="fastGN1 r29",
        linestyle="dashed",
    ),
    key="fastGN1_r29",
)
plot_roc.add_roc(
    Roc(
        sig_eff,
        fastGN1_ujets_rej_r30,
        n_test=n_jets_light_r30,
        rej_class="ujets",
        signal_class="bjets",
        label="fastGN1 r30",
        linestyle="solid",
    ),
    key="fastGN1_r30",
    reference_key="fastGN1_r29",
)
plot_roc.add_roc(
    Roc(
        sig_eff,
        fastdips_ujets_rej_r29,
        n_test=n_jets_light_r29,
        rej_class="ujets",
        signal_class="bjets",
        label="fastDIPS r29",
        linestyle="dashed",
    ),
    key="fastDIPS_r29",
)
plot_roc.add_roc(
    Roc(
        sig_eff,
        fastdips_ujets_rej_r30,
        n_test=n_jets_light_r30,
        rej_class="ujets",
        signal_class="bjets",
        label="fastDIPS r30",
        linestyle="solid",
    ),
    key="fastDIPS_r30",
    reference_key="fastDIPS_r29",
)
```

![roc](https://github.com/umami-hep/puma/assets/5699190/11701219-4135-44c5-adf9-c54722615e3c)
