### PR TITLE
HL Fraction scan bugfix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- HL fraction scan plot bugfix [!201](https://github.com/umami-hep/puma/pull/201)
 - Replace error hatching with filling for histograms [!194](https://github.com/umami-hep/puma/pull/194)
 - Add efficiency string to fc plots [!193](https://github.com/umami-hep/puma/pull/193)
 - Add option to deterime optimal fc [!188](https://github.com/umami-hep/puma/pull/188)

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -584,7 +584,6 @@ class Results:
             else:
                 plot.xlabel = self.backgrounds[0].rej_str
                 plot.ylabel = self.backgrounds[1].rej_str
-
-            # Draw and save the plot
-            plot.draw()
-            plot.savefig(self.get_filename("fraction_scan", suffix))
+        # Draw and save the plot
+        plot.draw()
+        plot.savefig(self.get_filename("fraction_scan", suffix))

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -216,7 +216,7 @@ class ResultsPlotsTestCase(unittest.TestCase):
                         "expected_plots/test_bjets_fraction_scan.png",
                     ),
                     results.get_filename("fraction_scan"),
-                    tol=5,
+                    tol=1,
                 ),
             )
 
@@ -237,6 +237,6 @@ class ResultsPlotsTestCase(unittest.TestCase):
                         "expected_plots/test_cjets_fraction_scan.png",
                     ),
                     results.get_filename("fraction_scan"),
-                    tol=5,
+                    tol=1,
                 ),
             )


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fix bug in HL fraction scan plot: move plot/savefig outside of the loop.


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] ~[Documentation](https://umami-hep.github.io/puma/)~
