### PR TITLE
Add per tagger cuts to results

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Add tagger specific cuts to results [!205](https://github.com/umami-hep/puma/pull/205)
+
 ### [v0.2.8] (2023/08/09)
 
 - HL fraction scan plot bugfix [!201](https://github.com/umami-hep/puma/pull/201)

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -460,12 +460,10 @@ class Results:
                 )
             )
 
-        disc_cut_in_kwargs = "disc_cut" in kwargs
-        working_point_in_kwargs = "working_point" in kwargs
         for tagger in self.taggers.values():
-            if not disc_cut_in_kwargs:
+            if "disc_cut" not in kwargs:
                 kwargs["disc_cut"] = tagger.disc_cut
-            if not working_point_in_kwargs:
+            if "working_point" not in kwargs:
                 kwargs["working_point"] = tagger.working_point
 
             discs = tagger.discriminant(self.signal)

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -19,6 +19,7 @@ from puma import (
     VarVsEff,
     VarVsEffPlot,
 )
+from puma.hlplots.tagger import Tagger
 from puma.metrics import calc_eff, calc_rej
 from puma.utils import get_good_linestyles
 
@@ -87,30 +88,28 @@ class Results:
 
     def add_taggers_from_file(  # pylint: disable=R0913
         self,
-        taggers,
-        file_path,
+        taggers: list[Tagger],
+        file_path: Path | str,
         key="jets",
         label_var="HadronConeExclTruthLabelID",
-        cuts=None,
-        num_jets=None,
-        perf_var=None,
+        cuts: Cuts | list | None = None,
+        num_jets: int | None = None,
+        perf_var: str | None = None,
     ):
-        """Add taggers from file.
-
-        # TODO: proper cuts class implementation
+        """Load one or more taggers from a common file.
 
         Parameters
         ----------
-        taggers : list
+        taggers : list[Tagger]
             List of taggers to add
-        file_path : str
+        file_path : str | Path
             Path to file
         key : str, optional
             Key in file, by default 'jets'
         label_var : str
-            Label variable to use
-        cuts : Cuts | list
-            List of cuts to apply
+            Label variable to use, by default 'HadronConeExclTruthLabelID'
+        cuts : Cuts | list, optional
+            Cuts to apply, by default None
         num_jets : int, optional
             Number of jets to load from the file, by default all jets
         perf_var : np.ndarray, optional
@@ -118,35 +117,48 @@ class Results:
         """
         # set tagger output nodes
         for tagger in taggers:
-            if tagger.output_nodes is None:
-                tagger.output_nodes = self.flavours
+            tagger.output_nodes = self.flavours
 
         # get a list of all variables to be loaded from the file
         if not isinstance(cuts, Cuts):
             cuts = Cuts.empty() if cuts is None else Cuts.from_list(cuts)
         var_list = sum([tagger.variables for tagger in taggers], [label_var])
         var_list += cuts.variables
+        var_list += sum([t.cuts.variables for t in taggers if t.cuts is not None], [])
         var_list = list(set(var_list + [self.perf_var]))
 
         # load data
         reader = H5Reader(file_path, precision="full")
         data = reader.load({key: var_list}, num_jets)[key]
 
-        # apply cuts
-        idx, data = cuts(data)
-        if perf_var is not None:
-            perf_var = perf_var[idx]
+        # apply common cuts
+        if cuts:
+            idx, data = cuts(data)
+            if perf_var is not None:
+                perf_var = perf_var[idx]
 
-        # attach data to tagger objects
+        # for each tagger
         for tagger in taggers:
-            tagger.extract_tagger_scores(data, source_type="structured_array")
-            tagger.labels = np.array(data[label_var], dtype=[(label_var, "i4")])
+            sel_data = data
+            sel_perf_var = perf_var
+
+            # apply tagger specific cuts
+            if tagger.cuts:
+                idx, sel_data = tagger.cuts(data)
+                if perf_var is not None:
+                    sel_perf_var = perf_var[idx]
+
+            # attach data to tagger objects
+            tagger.extract_tagger_scores(sel_data, source_type="structured_array")
+            tagger.labels = np.array(sel_data[label_var], dtype=[(label_var, "i4")])
             if perf_var is None:
-                tagger.perf_var = data[self.perf_var]
+                tagger.perf_var = sel_data[self.perf_var]
                 if any(x in self.perf_var for x in ["pt", "mass"]):
                     tagger.perf_var = tagger.perf_var * 0.001
             else:
-                tagger.perf_var = perf_var
+                tagger.perf_var = sel_perf_var
+
+            # add tagger to results
             self.add(tagger)
 
     def __getitem__(self, tagger_name: str):

--- a/puma/hlplots/tagger.py
+++ b/puma/hlplots/tagger.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 import h5py
 import numpy as np
 import pandas as pd
-from ftag import Flavour, Flavours, get_discriminant
+from ftag import Cuts, Flavour, Flavours, get_discriminant
 
 from puma.utils import logger
 
@@ -33,6 +33,9 @@ class Tagger:
     working_point: float = None
     f_c: float = None
     f_b: float = None
+
+    # this is only used by the Results class atm
+    cuts: Cuts | None = None
 
     def __post_init__(self):
         if self.label is None:

--- a/puma/hlplots/tagger.py
+++ b/puma/hlplots/tagger.py
@@ -20,6 +20,8 @@ class Tagger:
     label: str = None
     reference: bool = False
     colour: str = None
+    f_c: float = None
+    f_b: float = None
 
     # commonly set by the Results class
     scores: np.ndarray = None
@@ -31,15 +33,15 @@ class Tagger:
 
     disc_cut: float = None
     working_point: float = None
-    f_c: float = None
-    f_b: float = None
 
     # this is only used by the Results class atm
-    cuts: Cuts | None = None
+    cuts: Cuts | list | None = None
 
     def __post_init__(self):
         if self.label is None:
             self.label = self.name
+        if isinstance(self.cuts, list):
+            self.cuts = Cuts.from_list(self.cuts)
 
     def __repr__(self):
         return f"{self.name} ({self.label})"

--- a/puma/hlplots/tagger.py
+++ b/puma/hlplots/tagger.py
@@ -22,6 +22,11 @@ class Tagger:
     colour: str = None
     f_c: float = None
     f_b: float = None
+    disc_cut: float = None
+    working_point: float = None
+
+    # this is only read by the Results class
+    cuts: Cuts | list | None = None
 
     # commonly set by the Results class
     scores: np.ndarray = None
@@ -30,12 +35,6 @@ class Tagger:
     output_nodes: list = field(
         default_factory=lambda: [Flavours.ujets, Flavours.cjets, Flavours.bjets]
     )
-
-    disc_cut: float = None
-    working_point: float = None
-
-    # this is only used by the Results class atm
-    cuts: Cuts | list | None = None
 
     def __post_init__(self):
         if self.label is None:

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -60,6 +60,17 @@ class ResultsTestCase(unittest.TestCase):
         results.add_taggers_from_file(taggers, fname)
         self.assertEqual(list(results.taggers.values()), taggers)
 
+    def test_add_taggers_with_cuts(self):
+        tempfile.TemporaryDirectory()  # pylint: disable=R1732
+        np.random.default_rng(seed=16)
+        fname = get_mock_file()[0]
+        cuts = [("eta", ">", 0)]
+        tagger_cuts = [("pt", ">", 20)]
+        results = Results(signal="bjets", sample="test")
+        taggers = [Tagger("MockTagger", cuts=tagger_cuts)]
+        results.add_taggers_from_file(taggers, fname, cuts=cuts)
+        self.assertEqual(list(results.taggers.values()), taggers)
+
 
 class ResultsPlotsTestCase(unittest.TestCase):
     """Test class for the Results class running plots."""


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Add the option to add specific cuts to each tagger, useful when making train/val/test comparisons

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
