### PR TITLE
Add weight support for eff calculation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Add weight support for efficiency calculation [!206](https://github.com/umami-hep/puma/pull/206)
 - Add tagger specific cuts to results [!205](https://github.com/umami-hep/puma/pull/205)
 
 ### [v0.2.8] (2023/08/09)

--- a/puma/integrated_eff.py
+++ b/puma/integrated_eff.py
@@ -48,12 +48,8 @@ class IntegratedEfficiency(PlotLineObject):
             If `sig_eff` and `bkg_rej` have a different shape
         """
         super().__init__(**kwargs)
-        self.disc_sig = (
-            disc_sig if isinstance(disc_sig, np.ndarray) else np.array(disc_sig)
-        )
-        self.disc_bkg = (
-            disc_bkg if isinstance(disc_bkg, np.ndarray) else np.array(disc_bkg)
-        )
+        self.disc_sig = np.asarray(disc_sig)
+        self.disc_bkg = np.asarray(disc_bkg)
         self.n_vals = n_vals
         self.tagger = tagger
         self.key = key

--- a/puma/integrated_eff.py
+++ b/puma/integrated_eff.py
@@ -48,8 +48,12 @@ class IntegratedEfficiency(PlotLineObject):
             If `sig_eff` and `bkg_rej` have a different shape
         """
         super().__init__(**kwargs)
-        self.disc_sig = disc_sig
-        self.disc_bkg = disc_bkg
+        self.disc_sig = (
+            disc_sig if isinstance(disc_sig, np.ndarray) else np.array(disc_sig)
+        )
+        self.disc_bkg = (
+            disc_bkg if isinstance(disc_bkg, np.ndarray) else np.array(disc_bkg)
+        )
         self.n_vals = n_vals
         self.tagger = tagger
         self.key = key

--- a/puma/metrics.py
+++ b/puma/metrics.py
@@ -71,13 +71,19 @@ def calc_eff(
 
     Returns
     -------
-    eff : np.ndarray
+    eff : float or np.ndarray
         Efficiency.
-    cutvalue : np.ndarray
+        Return float if target_eff is a float, else np.ndarray
+    cutvalue : float or np.ndarray
         Cutvalue if return_cuts is True.
+        Return float if target_eff is a float, else np.ndarray
     """
     # TODO: with python 3.10 using type union operator
     # float | np.ndarray for both target_eff and the returned values
+    return_float = False
+    if isinstance(target_eff, float):
+        return_float = True
+
     target_eff = np.asarray([target_eff]).flatten()
 
     cutvalue = weighted_percentile(sig_disc, 1.0 - target_eff, weights=sig_weights)
@@ -89,6 +95,11 @@ def calc_eff(
     )
     eff = hist[::-1].cumsum()[-2::-1] / hist.sum()
     eff = eff[sorted_args]
+
+    if return_float:
+        eff = eff[0]
+        cutvalue = cutvalue[0]
+
     if return_cuts:
         return eff, cutvalue
     return eff

--- a/puma/tests/test_metrics.py
+++ b/puma/tests/test_metrics.py
@@ -102,15 +102,15 @@ class CalcEffAndRejTestCase(unittest.TestCase):
         )
         # the values here differ slightly from the values of the analytical integral,
         # since we use random numbers
-        np.testing.assert_array_almost_equal(cut, np.array([1.9956997]))
-        np.testing.assert_array_almost_equal(bkg_eff, np.array([0.02367]))
+        self.assertAlmostEqual(cut, 1.9956997)
+        self.assertAlmostEqual(bkg_eff, 0.02367)
 
         # same for rejection, just use rej = 1 / eff
         bkg_rej, cut = calc_rej(
             self.disc_sig, self.disc_bkg, target_eff=0.841345, return_cuts=True
         )
-        np.testing.assert_array_almost_equal(cut, np.array([1.9956997]))
-        np.testing.assert_array_almost_equal(bkg_rej, np.array([1 / 0.02367]))
+        self.assertAlmostEqual(cut, 1.9956997)
+        self.assertAlmostEqual(bkg_rej, 1 / 0.02367)
 
     def test_array_target(self):
         """Test efficiency and cut value calculation for list of target efficiencies."""

--- a/puma/tests/test_metrics.py
+++ b/puma/tests/test_metrics.py
@@ -102,15 +102,15 @@ class CalcEffAndRejTestCase(unittest.TestCase):
         )
         # the values here differ slightly from the values of the analytical integral,
         # since we use random numbers
-        self.assertAlmostEqual(cut, 1.9956997)
-        self.assertAlmostEqual(bkg_eff, 0.02367)
+        np.testing.assert_array_almost_equal(cut, np.array([1.9956997]))
+        np.testing.assert_array_almost_equal(bkg_eff, np.array([0.02367]))
 
         # same for rejection, just use rej = 1 / eff
         bkg_rej, cut = calc_rej(
             self.disc_sig, self.disc_bkg, target_eff=0.841345, return_cuts=True
         )
-        self.assertAlmostEqual(cut, 1.9956997)
-        self.assertAlmostEqual(bkg_rej, 1 / 0.02367)
+        np.testing.assert_array_almost_equal(cut, np.array([1.9956997]))
+        np.testing.assert_array_almost_equal(bkg_rej, np.array([1 / 0.02367]))
 
     def test_array_target(self):
         """Test efficiency and cut value calculation for list of target efficiencies."""


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Improve the *efficiency* of the efficiency calculation
* Add weight support
* Fix possible input issue with `IntegratedEff` plot 

Relates to the following issues

* #197 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
