### PR TITLE
Generalise ROC curve ratio grouping

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### [Latest]
 
 - Add tagger specific cuts to results [!205](https://github.com/umami-hep/puma/pull/205)
+- Generalise ROC curve ratio grouping [!202](https://github.com/umami-hep/puma/pull/202)
 
 ### [v0.2.8] (2023/08/09)
 

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -328,7 +328,7 @@ class RocPlot(PlotBase):
                 raise ValueError(
                     "You cannot set more rejection classes than available ratio panels."
                 )
-            self.reference_roc[rej_class][ratio_group] = key
+            self.reference_roc[rej_class] = {ratio_group: key}
         else:
             if self.reference_roc[rej_class].get(ratio_group):
                 logger.warning(

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -298,7 +298,8 @@ class RocPlot(PlotBase):
             )
             self.set_roc_reference(key, roc_curve.rej_class, roc_curve.ratio_group)
 
-    def set_roc_reference(self,
+    def set_roc_reference(
+        self,
         key: str,
         rej_class: Flavour,
         ratio_group: str = None,
@@ -321,7 +322,7 @@ class RocPlot(PlotBase):
         """
         if self.reference_roc is None:
             self.reference_roc = {}
-            self.reference_roc[rej_class] = { ratio_group : key  }
+            self.reference_roc[rej_class] = {ratio_group: key  }
         elif rej_class not in self.reference_roc:
             if len(self.reference_roc) >= self.n_ratio_panels:
                 raise ValueError(
@@ -416,7 +417,9 @@ class RocPlot(PlotBase):
             if elem.rej_class != rej_class:
                 continue
 
-            if self.reference_roc and self.reference_roc[rej_class].get(elem.ratio_group):
+            if self.reference_roc and self.reference_roc[rej_class].get(
+                elem.ratio_group
+            ):
                 ratio_sig_eff, ratio, ratio_err = elem.divide(
                     self.rocs[self.reference_roc[rej_class][elem.ratio_group]]
                 )

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -23,7 +23,7 @@ class Roc(PlotLineObject):
         rej_class: str | Flavour = None,
         signal_class: str = None,
         key: str = None,
-        reference_roc_key: str = None,
+        ratio_group: str = None,
         **kwargs,
     ) -> None:
         """Initialise properties of roc curve object.
@@ -44,6 +44,8 @@ class Roc(PlotLineObject):
             by default None
         key : str
             Identifier for roc curve e.g. tagger, by default None
+        ratio_group : str, optional
+            Identifies the reference ROC group for ratio calculation, by default None
         **kwargs : kwargs
             Keyword arguments passed to `puma.PlotLineObject`
 
@@ -66,7 +68,7 @@ class Roc(PlotLineObject):
             Flavours[rej_class] if isinstance(rej_class, str) else rej_class
         )
         self.key = key
-        self.reference_roc_key = reference_roc_key
+        self.ratio_group = ratio_group if ratio_group else str(rej_class)
 
     def binomial_error(self, norm: bool = False, n_test: int = None) -> np.ndarray:
         """Calculate binomial error of roc curve.
@@ -222,7 +224,6 @@ class RocPlot(PlotBase):
         roc_curve: object,
         key: str = None,
         reference: bool = False,
-        reference_key: str = None,
     ):
         """Adding puma.Roc object to figure.
 
@@ -234,9 +235,6 @@ class RocPlot(PlotBase):
             Unique identifier for roc_curve, by default None
         reference : bool, optional
             If roc is used as reference for ratio calculation, by default False
-        reference_key : str, optional
-            Identifier of the reference ROC curve for ratio calculation if
-            the rejection class has no class-wide reference, by default None
 
         Raises
         ------
@@ -298,13 +296,13 @@ class RocPlot(PlotBase):
             logger.debug(
                 "Setting roc %s as reference for %s.", key, roc_curve.rej_class
             )
-            self.set_roc_reference(key, roc_curve.rej_class)
+            self.set_roc_reference(key, roc_curve.rej_class, roc_curve.ratio_group)
 
-        if reference_key:
-            logger.debug("Setting roc %s as reference for %s", reference_key, key)
-            roc_curve.reference_roc_key = reference_key
-
-    def set_roc_reference(self, key: str, rej_class: Flavour):
+    def set_roc_reference(self,
+        key: str,
+        rej_class: Flavour,
+        ratio_group: str = None,
+    ):
         """Setting the reference roc curves used in the ratios.
 
         Parameters
@@ -313,6 +311,8 @@ class RocPlot(PlotBase):
             Unique identifier of roc object
         rej_class : str
             Rejection class encoded in roc curve
+        ratio_group : str
+            Ratio group this roc is reference for, by default None
 
         Raises
         ------
@@ -321,23 +321,24 @@ class RocPlot(PlotBase):
         """
         if self.reference_roc is None:
             self.reference_roc = {}
-            self.reference_roc[rej_class] = key
+            self.reference_roc[rej_class] = { ratio_group : key  }
         elif rej_class not in self.reference_roc:
             if len(self.reference_roc) >= self.n_ratio_panels:
                 raise ValueError(
                     "You cannot set more rejection classes than available ratio panels."
                 )
-            self.reference_roc[rej_class] = key
+            self.reference_roc[rej_class][ratio_group] = key
         else:
-            logger.warning(
-                (
-                    "You specified a second roc curve %s as reference for ratio. "
-                    "Using it as new reference instead of %s."
-                ),
-                key,
-                self.reference_roc[rej_class],
-            )
-            self.reference_roc[rej_class] = key
+            if self.reference_roc[rej_class].get(ratio_group):
+                logger.warning(
+                    (
+                        "You specified a second roc curve %s as reference for ratio. "
+                        "Using it as new reference instead of %s."
+                    ),
+                    key,
+                    self.reference_roc[rej_class][ratio_group],
+                )
+            self.reference_roc[rej_class][ratio_group] = key
 
     def set_ratio_class(self, ratio_panel: int, rej_class: str | Flavour):
         """Associate the rejection class to a ratio panel adn set the legend label.
@@ -415,13 +416,9 @@ class RocPlot(PlotBase):
             if elem.rej_class != rej_class:
                 continue
 
-            if self.reference_roc:
+            if self.reference_roc and self.reference_roc[rej_class].get(elem.ratio_group):
                 ratio_sig_eff, ratio, ratio_err = elem.divide(
-                    self.rocs[self.reference_roc[rej_class]]
-                )
-            elif elem.reference_roc_key:
-                ratio_sig_eff, ratio, ratio_err = elem.divide(
-                    self.rocs[elem.reference_roc_key]
+                    self.rocs[self.reference_roc[rej_class][elem.ratio_group]]
                 )
             else:
                 ratio_sig_eff, ratio, ratio_err = elem.divide(elem)

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -322,7 +322,7 @@ class RocPlot(PlotBase):
         """
         if self.reference_roc is None:
             self.reference_roc = {}
-            self.reference_roc[rej_class] = {ratio_group: key  }
+            self.reference_roc[rej_class] = {ratio_group: key}
         elif rej_class not in self.reference_roc:
             if len(self.reference_roc) >= self.n_ratio_panels:
                 raise ValueError(


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Generalise ROC curve ratio grouping by adding the `ratio_group` parameter to the `ROC` class
* Revert explicit setting the ratio reference as implemented in #200 as it is not needed anymore

Relates to the following issues

* #202 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
