### PR TITLE
Improve performance per variable plots

### DIFF
--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -61,11 +61,8 @@ results.plot_rocs()
 
 # eff/rej vs. variable plots
 logger.info("Plotting efficiency/rejection vs pT curves.")
-results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$\n70% WP"
+results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$"
 
-# you can either specify a WP per tagger, e.g.
-# dips.working_point = 0.7
-# rnnip.working_point = 0.7
 # or alternatively also pass the argument `working_point` to the plot_var_perf function.
 # specifying the `disc_cut` per tagger is also possible.
 results.plot_var_perf(
@@ -75,7 +72,7 @@ results.plot_var_perf(
 )
 
 results.atlas_second_tag = (
-    "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$\n70% WP per bin"
+    "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$"
 )
 results.plot_var_perf(
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],

--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -71,7 +71,7 @@ results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$\n70% WP
 results.plot_var_perf(
     working_point=0.7,
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
-    flat_eff_bin=False,
+    flat_per_bin=False,
 )
 
 results.atlas_second_tag = (
@@ -79,7 +79,7 @@ results.atlas_second_tag = (
 )
 results.plot_var_perf(
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
-    flat_eff_bin=True,
+    flat_per_bin=True,
     working_point=0.7,
     h_line=0.7,
     disc_cut=None,

--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -84,6 +84,14 @@ results.plot_var_perf(
     h_line=0.7,
     disc_cut=None,
 )
+# flat rej vs. variable plots, a third tag is added relating to the fixed rejection per bin
+results.atlas_second_tag = (
+    "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$"   
+)
+results.plot_flat_rej_var_perf(
+    fixed_rejections={'cjets' : 2.2, 'ujets' : 1.2}, 
+    bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+)
 
 # fraction scan plots
 logger.info("Plotting fraction scans.")

--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -84,7 +84,8 @@ results.plot_var_perf(
     h_line=0.7,
     disc_cut=None,
 )
-# flat rej vs. variable plots, a third tag is added relating to the fixed rejection per bin
+# flat rej vs. variable plots, a third tag is added relating to the fixed
+#  rejection per bin
 results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$"
 results.plot_flat_rej_var_perf(
     fixed_rejections={"cjets": 2.2, "ujets": 1.2},

--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -71,9 +71,7 @@ results.plot_var_perf(
     flat_per_bin=False,
 )
 
-results.atlas_second_tag = (
-    "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$"
-)
+results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$"
 results.plot_var_perf(
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
     flat_per_bin=True,

--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -85,11 +85,9 @@ results.plot_var_perf(
     disc_cut=None,
 )
 # flat rej vs. variable plots, a third tag is added relating to the fixed rejection per bin
-results.atlas_second_tag = (
-    "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$"   
-)
+results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$"
 results.plot_flat_rej_var_perf(
-    fixed_rejections={'cjets' : 2.2, 'ujets' : 1.2}, 
+    fixed_rejections={"cjets": 2.2, "ujets": 1.2},
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
 )
 

--- a/examples/high_level_plots.py
+++ b/examples/high_level_plots.py
@@ -71,7 +71,7 @@ results.atlas_second_tag = "$\\sqrt{s}=13$ TeV, dummy jets \n$t\\bar{t}$\n70% WP
 results.plot_var_perf(
     working_point=0.7,
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
-    fixed_eff_bin=False,
+    flat_eff_bin=False,
 )
 
 results.atlas_second_tag = (
@@ -79,7 +79,7 @@ results.atlas_second_tag = (
 )
 results.plot_var_perf(
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
-    fixed_eff_bin=True,
+    flat_eff_bin=True,
     working_point=0.7,
     h_line=0.7,
     disc_cut=None,

--- a/examples/plot_pt_vs_eff.py
+++ b/examples/plot_pt_vs_eff.py
@@ -76,7 +76,7 @@ rnnip_light = VarVsEff(
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
     working_point=0.7,
     disc_cut=None,
-    flat_eff_bin=False,
+    flat_per_bin=False,
     label="RNNIP",
 )
 dips_light = VarVsEff(
@@ -87,7 +87,7 @@ dips_light = VarVsEff(
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
     working_point=0.7,
     disc_cut=None,
-    flat_eff_bin=False,
+    flat_per_bin=False,
     label="DIPS",
 )
 

--- a/examples/plot_pt_vs_eff.py
+++ b/examples/plot_pt_vs_eff.py
@@ -76,7 +76,7 @@ rnnip_light = VarVsEff(
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
     working_point=0.7,
     disc_cut=None,
-    fixed_eff_bin=False,
+    flat_eff_bin=False,
     label="RNNIP",
 )
 dips_light = VarVsEff(
@@ -87,7 +87,7 @@ dips_light = VarVsEff(
     bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
     working_point=0.7,
     disc_cut=None,
-    fixed_eff_bin=False,
+    flat_eff_bin=False,
     label="DIPS",
 )
 

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -465,7 +465,8 @@ class Results:
             self.signal,
             working_point=working_point,
             disc_cut=disc_cut,
-            flat_per_bin=kwargs.get("flat_per_bin", False),)
+            flat_per_bin=kwargs.get("flat_per_bin", False),
+        )
         plot_bkg = []
         for background in self.backgrounds:
             plot_bkg.append(
@@ -481,14 +482,13 @@ class Results:
                 )
             )
             plot_bkg[-1].apply_modified_atlas_second_tag(
-                    self.signal,
-                    working_point=working_point,
-                    disc_cut=disc_cut,
-                    flat_per_bin=kwargs.get("flat_per_bin", False),
-                )
+                self.signal,
+                working_point=working_point,
+                disc_cut=disc_cut,
+                flat_per_bin=kwargs.get("flat_per_bin", False),
+            )
 
         for tagger in self.taggers.values():
-
             discs = tagger.discriminant(self.signal)
             is_signal = tagger.is_flav(self.signal)
             plot_sig_eff.add(

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -415,7 +415,7 @@ class Results:
         self,
         suffix: str = None,
         xlabel: str = r"$p_{T}$ [GeV]",
-        x_var: str = 'pt',
+        x_var: str = "pt",
         h_line: float = None,
         **kwargs,
     ):
@@ -500,27 +500,34 @@ class Results:
         if h_line:
             plot_sig_eff.draw_hline(h_line)
 
-        
-        plot_base = "profile_flat_per_bin" if kwargs.get("fixed_eff_bin") else "profile_fixed_cut"
+        plot_base = (
+            "profile_flat_per_bin"
+            if kwargs.get("fixed_eff_bin")
+            else "profile_fixed_cut"
+        )
         plot_details = f"{self.signal}_eff_vs_{x_var}_"
         plot_suffix = f"_{suffix}" if suffix else ""
         plot_sig_eff.savefig(self.get_filename(plot_details + plot_base, plot_suffix))
         for i, background in enumerate(self.backgrounds):
             plot_bkg[i].draw()
             plot_details = f"{background}_rej_vs_{x_var}_"
-            plot_bkg[i].savefig(self.get_filename(plot_details + plot_base, plot_suffix))
+            plot_bkg[i].savefig(
+                self.get_filename(plot_details + plot_base, plot_suffix)
+            )
 
-    def plot_flat_rej_var_perf(self,
-            fixed_rejections : dict[Flavour, float],
-            suffix: str = None,
-            xlabel: str = r"$p_{T}$ [GeV]",
-            x_var: str = 'pt',
-            h_line: float = None,
-            **kwargs,
-            ):
+    def plot_flat_rej_var_perf(
+        self,
+        fixed_rejections: dict[Flavour, float],
+        suffix: str = None,
+        xlabel: str = r"$p_{T}$ [GeV]",
+        x_var: str = "pt",
+        h_line: float = None,
+        **kwargs,
+    ):
         """Plot signal efficiency as a function of a variable, with a fixed enforce background
         rejection for each bin
-        
+
+
         Parameters
         ----------
         fixed_rejections : dict[Flavour, float]
@@ -537,11 +544,16 @@ class Results:
         **kwargs : kwargs
             key word arguments for `puma.VarVsEff`
         """
-        assert all([b.name in fixed_rejections.keys() for b in self.backgrounds]), "Not all backgrounds have a fixed rejection"
+        assert all(
+            [b.name in fixed_rejections for b in self.backgrounds]
+        ), "Not all backgrounds have a fixed rejection"
         plot_bkg = []
-        print('tag: ', self.atlas_second_tag)
+        print("tag: ", self.atlas_second_tag)
         for background in self.backgrounds:
-            modified_second_tag = f"{self.atlas_second_tag}\nFixed {background.rej_str} = {fixed_rejections[background.name]} per bin"
+            modified_second_tag = (
+                f"{self.atlas_second_tag}\nFixed {background.rej_str} ="
+                f" {fixed_rejections[background.name]} per bin"
+            )
             plot_bkg.append(
                 VarVsEffPlot(
                     mode="bkg_eff",
@@ -555,9 +567,9 @@ class Results:
                 )
             )
         for tagger in self.taggers.values():
-            if 'disc_cut' in kwargs:
+            if "disc_cut" in kwargs:
                 raise ValueError("disc_cut should not be set for this plot")
-            if 'working_point' in kwargs:
+            if "working_point" in kwargs:
                 raise ValueError("working_point should not be set for this plot")
 
             discs = tagger.discriminant(self.signal)
@@ -577,14 +589,13 @@ class Results:
                         disc_bkg=discs[is_signal],
                         label=tagger.label,
                         colour=tagger.colour,
-                        working_point=1/fixed_rejections[background.name],
+                        working_point=1 / fixed_rejections[background.name],
                         fixed_eff_bin=True,
                         **kwargs,
                     ),
                     reference=tagger.reference,
                 )
 
-        
         plot_suffix = f"_{suffix}" if suffix else ""
         for i, background in enumerate(self.backgrounds):
             plot_bkg[i].draw()
@@ -592,7 +603,9 @@ class Results:
                 plot_bkg[i].draw_hline(h_line)
             plot_details = f"{self.signal}_eff_vs_{x_var}_"
             plot_base = f"profile_flat_{background}_{fixed_rejections[background.name]}_rej_per_bin"
-            plot_bkg[i].savefig(self.get_filename(plot_details + plot_base, plot_suffix))
+            plot_bkg[i].savefig(
+                self.get_filename(plot_details + plot_base, plot_suffix)
+            )
 
     def plot_fraction_scans(
         self,

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -431,7 +431,8 @@ class Results:
         xlabel : regexp, optional
             _description_, by default "$p_{T}$ [GeV]"
         x_var: str, optional
-            The x axis variable, used for providing details to the plot name, default is 'pt'
+            The x axis variable, used for providing details to the plot name, default
+            is 'pt'
         h_line : float, optional
             draws a horizonatal line in the signal efficiency plot
         **kwargs : kwargs

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -525,8 +525,8 @@ class Results:
         h_line: float = None,
         **kwargs,
     ):
-        """Plot signal efficiency as a function of a variable, with a fixed enforce background
-        rejection for each bin
+        """Plot signal efficiency as a function of a variable, with a fixed enforce
+        background rejection for each bin
 
 
         Parameters
@@ -539,7 +539,8 @@ class Results:
         xlabel : regexp, optional
             _description_, by default "$p_{T}$ [GeV]"
         x_var: str, optional
-            The x axis variable, used for providing details to the plot name, default is 'pt'
+            The x axis variable, used for providing details to the plot name,
+            default is 'pt'
         h_line : float, optional
             draws a horizonatal line in the signal efficiency plot
         **kwargs : kwargs
@@ -576,11 +577,12 @@ class Results:
             is_signal = tagger.is_flav(self.signal)
             for i, background in enumerate(self.backgrounds):
                 is_bkg = tagger.is_flav(background)
-                # We want x bins to all have the same background rejection, so we select the
-                # plot mode as 'bkg_eff', and then treat the signal as the background here.
-                # I.e, the API plots 'bkg_eff' on the y axis, while keeping the 'sig_eff' a flat
-                # rate on the x axis, we therefore pass the signal as the background, and the
-                # background as the signal.
+                # We want x bins to all have the same background rejection, so we
+                # select the plot mode as 'bkg_eff', and then treat the signal as
+                # the background here. I.e, the API plots 'bkg_eff' on the y axis,
+                # while keeping the 'sig_eff' a flat rate on the x axis, we therefore
+                # pass the signal as the background, and the background as the
+                # signal.
                 plot_bkg[i].add(
                     VarVsEff(
                         x_var_sig=tagger.perf_var[is_bkg],
@@ -602,7 +604,10 @@ class Results:
             if h_line:
                 plot_bkg[i].draw_hline(h_line)
             plot_details = f"{self.signal}_eff_vs_{x_var}_"
-            plot_base = f"profile_flat_{background}_{int(fixed_rejections[background.name])}_rej_per_bin"
+            plot_base = (
+                f"profile_flat_{background}_"
+                + f"{int(fixed_rejections[background.name])}_rej_per_bin"
+            )
             plot_bkg[i].savefig(
                 self.get_filename(plot_details + plot_base, plot_suffix)
             )

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -416,9 +416,9 @@ class Results:
         suffix: str | None = None,
         xlabel: str = r"$p_{T}$ [GeV]",
         x_var: str = "pt",
-        h_line: float = None,
-        working_point: float = None,
-        disc_cut: float = None,
+        h_line: float | None = None,
+        working_point: float | None = None,
+        disc_cut: float | None = None,
         **kwargs,
     ):
         """Variable vs efficiency/rejection plot.
@@ -542,10 +542,10 @@ class Results:
     def plot_flat_rej_var_perf(
         self,
         fixed_rejections: dict[Flavour, float],
-        suffix: str = None,
+        suffix: str | None = None,
         xlabel: str = r"$p_{T}$ [GeV]",
         x_var: str = "pt",
-        h_line: float = None,
+        h_line: float | None = None,
         **kwargs,
     ):
         """Plot signal efficiency as a function of a variable, with a fixed enforce

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -580,7 +580,7 @@ class Results:
             )
             plot_bkg.append(
                 VarVsEffPlot(
-                    mode="bkg_eff",
+                    mode="bkg_eff_sig_err",
                     ylabel=self.signal.eff_str,
                     xlabel=xlabel,
                     logy=False,

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -552,7 +552,7 @@ class Results:
         plot_bkg = []
         for background in self.backgrounds:
             modified_second_tag = (
-                f"{self.atlas_second_tag}\nFixed {background.rej_str} ="
+                f"{self.atlas_second_tag}\nFixed {background.rej_str} of"
                 f" {fixed_rejections[background.name]} per bin"
             )
             plot_bkg.append(

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -503,7 +503,7 @@ class Results:
 
         plot_base = (
             "profile_flat_per_bin"
-            if kwargs.get("flat_eff_bin")
+            if kwargs.get("flat_per_bin")
             else "profile_fixed_cut"
         )
         plot_details = f"{self.signal}_eff_vs_{x_var}_"
@@ -592,7 +592,7 @@ class Results:
                         label=tagger.label,
                         colour=tagger.colour,
                         working_point=1 / fixed_rejections[background.name],
-                        flat_eff_bin=True,
+                        flat_per_bin=True,
                         **kwargs,
                     ),
                     reference=tagger.reference,

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -548,7 +548,6 @@ class Results:
             [b.name in fixed_rejections for b in self.backgrounds]
         ), "Not all backgrounds have a fixed rejection"
         plot_bkg = []
-        print("tag: ", self.atlas_second_tag)
         for background in self.backgrounds:
             modified_second_tag = (
                 f"{self.atlas_second_tag}\nFixed {background.rej_str} ="
@@ -602,7 +601,7 @@ class Results:
             if h_line:
                 plot_bkg[i].draw_hline(h_line)
             plot_details = f"{self.signal}_eff_vs_{x_var}_"
-            plot_base = f"profile_flat_{background}_{fixed_rejections[background.name]}_rej_per_bin"
+            plot_base = f"profile_flat_{background}_{int(fixed_rejections[background.name])}_rej_per_bin"
             plot_bkg[i].savefig(
                 self.get_filename(plot_details + plot_base, plot_suffix)
             )

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -415,6 +415,7 @@ class Results:
         self,
         suffix: str = None,
         xlabel: str = r"$p_{T}$ [GeV]",
+        x_var: str = 'pt',
         h_line: float = None,
         **kwargs,
     ):
@@ -429,6 +430,8 @@ class Results:
             suffix to add to output file name, by default None
         xlabel : regexp, optional
             _description_, by default "$p_{T}$ [GeV]"
+        x_var: str, optional
+            The x axis variable, used for providing details to the plot name, default is 'pt'
         h_line : float, optional
             draws a horizonatal line in the signal efficiency plot
         **kwargs : kwargs
@@ -497,15 +500,15 @@ class Results:
         if h_line:
             plot_sig_eff.draw_hline(h_line)
 
-        plot_base = "profile_flat" if kwargs.get("fixed_eff_bin") else "profile_fixed"
-        plot_suffix = f"{self.signal}_eff_{suffix}" if suffix else f"{self.signal}_eff"
-        plot_sig_eff.savefig(self.get_filename(plot_base, plot_suffix))
+        
+        plot_base = "profile_flat_per_bin" if kwargs.get("fixed_eff_bin") else "profile_fixed_cut"
+        plot_details = f"{self.signal}_eff_vs_{x_var}_"
+        plot_suffix = f"_{suffix}" if suffix else ""
+        plot_sig_eff.savefig(self.get_filename(plot_details + plot_base, plot_suffix))
         for i, background in enumerate(self.backgrounds):
             plot_bkg[i].draw()
-            plot_suffix = (
-                f"{background}_rej_{suffix}" if suffix else f"{background}_rej"
-            )
-            plot_bkg[i].savefig(self.get_filename(plot_base, plot_suffix))
+            plot_details = f"{background}_rej_vs_{x_var}_"
+            plot_bkg[i].savefig(self.get_filename(plot_details + plot_base, plot_suffix))
 
     def plot_fraction_scans(
         self,

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -502,7 +502,7 @@ class Results:
 
         plot_base = (
             "profile_flat_per_bin"
-            if kwargs.get("fixed_eff_bin")
+            if kwargs.get("flat_eff_bin")
             else "profile_fixed_cut"
         )
         plot_details = f"{self.signal}_eff_vs_{x_var}_"
@@ -590,7 +590,7 @@ class Results:
                         label=tagger.label,
                         colour=tagger.colour,
                         working_point=1 / fixed_rejections[background.name],
-                        fixed_eff_bin=True,
+                        flat_eff_bin=True,
                         **kwargs,
                     ),
                     reference=tagger.reference,

--- a/puma/hlplots/tagger.py
+++ b/puma/hlplots/tagger.py
@@ -22,8 +22,6 @@ class Tagger:
     colour: str = None
     f_c: float = None
     f_b: float = None
-    disc_cut: float = None
-    working_point: float = None
 
     # this is only read by the Results class
     cuts: Cuts | list | None = None

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -176,9 +176,15 @@ class ResultsPlotsTestCase(unittest.TestCase):
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
             )
 
-            self.assertIsFile(Path(tmp_file) / "test_bjets_bjets_eff_vs_pt_profile_fixed_cut_.png")
-            self.assertIsFile(Path(tmp_file) / "test_bjets_cjets_rej_vs_pt_profile_fixed_cut_.png")
-            self.assertIsFile(Path(tmp_file) / "test_bjets_ujets_rej_vs_pt_profile_fixed_cut_.png")
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_bjets_eff_vs_pt_profile_fixed_cut_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_cjets_rej_vs_pt_profile_fixed_cut_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_ujets_rej_vs_pt_profile_fixed_cut_.png"
+            )
 
     def test_plot_var_perf_cjets(self):
         """Test that png file is being created."""
@@ -196,9 +202,15 @@ class ResultsPlotsTestCase(unittest.TestCase):
                 h_line=self.dummy_tagger_1.working_point,
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
             )
-            self.assertIsFile(Path(tmp_file) / "test_cjets_cjets_eff_vs_pt_profile_fixed_cut_.png")
-            self.assertIsFile(Path(tmp_file) / "test_cjets_bjets_rej_vs_pt_profile_fixed_cut_.png")
-            self.assertIsFile(Path(tmp_file) / "test_cjets_ujets_rej_vs_pt_profile_fixed_cut_.png")
+            self.assertIsFile(
+                Path(tmp_file) / "test_cjets_cjets_eff_vs_pt_profile_fixed_cut_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_cjets_bjets_rej_vs_pt_profile_fixed_cut_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_cjets_ujets_rej_vs_pt_profile_fixed_cut_.png"
+            )
 
     def test_plot_fraction_scans_hbb_error(self):
         """Test that correct error is raised."""

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -227,8 +227,9 @@ class ResultsPlotsTestCase(unittest.TestCase):
                 )
 
     def test_plot_var_eff_per_flat_rej_err(self):
-        """Tests the performance vs flat rejection plots throws errors 
-        with invalid inputs"""
+        """Tests the performance vs flat rejection plots throws errors
+        with invalid inputs
+        """
         self.dummy_tagger_1.reference = True
         self.dummy_tagger_1.f_c = 0.05
         self.dummy_tagger_1.disc_cut = 2
@@ -318,7 +319,7 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results.plot_flat_rej_var_perf(
                 fixed_rejections={"cjets": 10, "ujets": 100},
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
-                h_line=0.5
+                h_line=0.5,
             )
             self.assertIsFile(
                 Path(tmp_file)

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -226,6 +226,30 @@ class ResultsPlotsTestCase(unittest.TestCase):
                     working_point=0.5,
                 )
 
+    def test_plot_var_eff_per_flat_rej_err(self):
+        """Tests the performance vs flat rejection plots throws errors 
+        with invalid inputs"""
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.f_c = 0.05
+        self.dummy_tagger_1.disc_cut = 2
+        rng = np.random.default_rng(seed=16)
+        self.dummy_tagger_1.perf_var = rng.exponential(
+            100, size=len(self.dummy_tagger_1.scores)
+        )
+        with tempfile.TemporaryDirectory() as tmp_file:
+            with self.assertRaises(ValueError):
+                results = Results(signal="bjets", sample="test", output_dir=tmp_file)
+                results.plot_flat_rej_var_perf(
+                    bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+                    fixed_rejections={"cjets": 10, "ujets": 100},
+                    working_point=0.5,
+                )
+                results.plot_flat_rej_var_perf(
+                    bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+                    fixed_rejections={"cjets": 10, "ujets": 100},
+                    disc_cut=0.5,
+                )
+
     def test_plot_var_perf_bjets(self):
         """Test that png file is being created."""
         self.dummy_tagger_1.reference = True
@@ -294,6 +318,7 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results.plot_flat_rej_var_perf(
                 fixed_rejections={"cjets": 10, "ujets": 100},
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+                h_line=0.5
             )
             self.assertIsFile(
                 Path(tmp_file)

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -176,9 +176,9 @@ class ResultsPlotsTestCase(unittest.TestCase):
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
             )
 
-            self.assertIsFile(Path(tmp_file) / "test_bjets_profile_fixed_bjets_eff.png")
-            self.assertIsFile(Path(tmp_file) / "test_bjets_profile_fixed_cjets_rej.png")
-            self.assertIsFile(Path(tmp_file) / "test_bjets_profile_fixed_ujets_rej.png")
+            self.assertIsFile(Path(tmp_file) / "test_bjets_bjets_eff_vs_pt_profile_fixed_cut_.png")
+            self.assertIsFile(Path(tmp_file) / "test_bjets_cjets_rej_vs_pt_profile_fixed_cut_.png")
+            self.assertIsFile(Path(tmp_file) / "test_bjets_ujets_rej_vs_pt_profile_fixed_cut_.png")
 
     def test_plot_var_perf_cjets(self):
         """Test that png file is being created."""
@@ -196,9 +196,9 @@ class ResultsPlotsTestCase(unittest.TestCase):
                 h_line=self.dummy_tagger_1.working_point,
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
             )
-            self.assertIsFile(Path(tmp_file) / "test_cjets_profile_fixed_cjets_eff.png")
-            self.assertIsFile(Path(tmp_file) / "test_cjets_profile_fixed_bjets_rej.png")
-            self.assertIsFile(Path(tmp_file) / "test_cjets_profile_fixed_ujets_rej.png")
+            self.assertIsFile(Path(tmp_file) / "test_cjets_cjets_eff_vs_pt_profile_fixed_cut_.png")
+            self.assertIsFile(Path(tmp_file) / "test_cjets_bjets_rej_vs_pt_profile_fixed_cut_.png")
+            self.assertIsFile(Path(tmp_file) / "test_cjets_ujets_rej_vs_pt_profile_fixed_cut_.png")
 
     def test_plot_fraction_scans_hbb_error(self):
         """Test that correct error is raised."""

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -160,6 +160,29 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results.plot_rocs()
             self.assertIsFile(results.get_filename("roc"))
 
+    def test_plot_var_perf_err(self):
+        """Tests the performance plots throws errors with invalid inputs"""
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.f_c = 0.05
+        self.dummy_tagger_1.disc_cut = 2
+        rng = np.random.default_rng(seed=16)
+        self.dummy_tagger_1.perf_var = rng.exponential(
+            100, size=len(self.dummy_tagger_1.scores)
+        )
+        with tempfile.TemporaryDirectory() as tmp_file:
+            results = Results(signal="bjets", sample="test", output_dir=tmp_file)
+            results.add(self.dummy_tagger_1)
+            with self.assertRaises(ValueError):
+                results.plot_var_perf(
+                    bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+                )
+            with self.assertRaises(ValueError):
+                results.plot_var_perf(
+                    bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+                    disc_cut=1,
+                    working_point=0.5,
+                )
+
     def test_plot_var_perf_bjets(self):
         """Test that png file is being created."""
         self.dummy_tagger_1.reference = True
@@ -174,6 +197,7 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results.add(self.dummy_tagger_1)
             results.plot_var_perf(
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+                working_point=0.7,
             )
 
             self.assertIsFile(
@@ -201,6 +225,7 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results.plot_var_perf(
                 h_line=self.dummy_tagger_1.working_point,
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+                working_point=0.7,
             )
             self.assertIsFile(
                 Path(tmp_file) / "test_cjets_cjets_eff_vs_pt_profile_fixed_cut_.png"

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -212,6 +212,53 @@ class ResultsPlotsTestCase(unittest.TestCase):
                 Path(tmp_file) / "test_cjets_ujets_rej_vs_pt_profile_fixed_cut_.png"
             )
 
+    def test_plot_beff_vs_flat_rej(self):
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.f_c = 0.05
+        self.dummy_tagger_1.working_point = 0.5
+        rng = np.random.default_rng(seed=16)
+        self.dummy_tagger_1.perf_var = rng.exponential(
+            100, size=len(self.dummy_tagger_1.scores)
+        )
+        with tempfile.TemporaryDirectory() as tmp_file:
+            results = Results(signal="bjets", sample="test", output_dir=tmp_file)
+            results.add(self.dummy_tagger_1)
+            results.plot_flat_rej_var_perf(
+                fixed_rejections={'cjets' : 10, 'ujets' : 100},
+                bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+            )
+            self.assertIsFile(
+                                           
+                Path(tmp_file) / "test_bjets_bjets_eff_vs_pt_profile_flat_cjets_10_rej_per_bin_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_bjets_eff_vs_pt_profile_flat_ujets_100_rej_per_bin_.png"
+            )
+
+    def test_plot_ceff_vs_flat_rej(self):
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.f_b = 0.05
+        self.dummy_tagger_1.working_point = 0.5
+        rng = np.random.default_rng(seed=16)
+        self.dummy_tagger_1.perf_var = rng.exponential(
+            100, size=len(self.dummy_tagger_1.scores)
+        )
+        with tempfile.TemporaryDirectory() as tmp_file:
+            results = Results(signal="cjets", sample="test", output_dir=tmp_file)
+            results.add(self.dummy_tagger_1)
+            results.plot_flat_rej_var_perf(
+                fixed_rejections={'bjets' : 10, 'ujets' : 100},
+                bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+            )
+            self.assertIsFile(
+                                           
+                Path(tmp_file) / "test_cjets_cjets_eff_vs_pt_profile_flat_bjets_10_rej_per_bin_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_cjets_cjets_eff_vs_pt_profile_flat_ujets_100_rej_per_bin_.png"
+            )
+
+
     def test_plot_fraction_scans_hbb_error(self):
         """Test that correct error is raised."""
         self.dummy_tagger_1.reference = True

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -224,15 +224,16 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results = Results(signal="bjets", sample="test", output_dir=tmp_file)
             results.add(self.dummy_tagger_1)
             results.plot_flat_rej_var_perf(
-                fixed_rejections={'cjets' : 10, 'ujets' : 100},
+                fixed_rejections={"cjets": 10, "ujets": 100},
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
             )
             self.assertIsFile(
-                                           
-                Path(tmp_file) / "test_bjets_bjets_eff_vs_pt_profile_flat_cjets_10_rej_per_bin_.png"
+                Path(tmp_file)
+                / "test_bjets_bjets_eff_vs_pt_profile_flat_cjets_10_rej_per_bin_.png"
             )
             self.assertIsFile(
-                Path(tmp_file) / "test_bjets_bjets_eff_vs_pt_profile_flat_ujets_100_rej_per_bin_.png"
+                Path(tmp_file)
+                / "test_bjets_bjets_eff_vs_pt_profile_flat_ujets_100_rej_per_bin_.png"
             )
 
     def test_plot_ceff_vs_flat_rej(self):
@@ -247,17 +248,17 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results = Results(signal="cjets", sample="test", output_dir=tmp_file)
             results.add(self.dummy_tagger_1)
             results.plot_flat_rej_var_perf(
-                fixed_rejections={'bjets' : 10, 'ujets' : 100},
+                fixed_rejections={"bjets": 10, "ujets": 100},
                 bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
             )
             self.assertIsFile(
-                                           
-                Path(tmp_file) / "test_cjets_cjets_eff_vs_pt_profile_flat_bjets_10_rej_per_bin_.png"
+                Path(tmp_file)
+                / "test_cjets_cjets_eff_vs_pt_profile_flat_bjets_10_rej_per_bin_.png"
             )
             self.assertIsFile(
-                Path(tmp_file) / "test_cjets_cjets_eff_vs_pt_profile_flat_ujets_100_rej_per_bin_.png"
+                Path(tmp_file)
+                / "test_cjets_cjets_eff_vs_pt_profile_flat_ujets_100_rej_per_bin_.png"
             )
-
 
     def test_plot_fraction_scans_hbb_error(self):
         """Test that correct error is raised."""

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -132,11 +132,6 @@ class TaggerTestCase(unittest.TestCase):
             dtype=[("dummy_pu", "f4"), ("dummy_pc", "f4"), ("dummy_pb", "f4")],
         )
 
-    def test_disc_cut_template(self):
-        """Test template with disc_cut."""
-        template_disc_cut = {"disc_cut": 1.5}
-        tagger = Tagger("dummy", **template_disc_cut)
-        self.assertEqual(tagger.disc_cut, 1.5)
 
     def test_errors(self):
         tagger = Tagger("dummy")

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -134,7 +134,6 @@ class TaggerTestCase(unittest.TestCase):
             dtype=[("dummy_pu", "f4"), ("dummy_pc", "f4"), ("dummy_pb", "f4")],
         )
 
-
     def test_errors(self):
         tagger = Tagger("dummy")
         tagger.scores = self.scores

--- a/puma/tests/test_var_vs_eff.py
+++ b/puma/tests/test_var_vs_eff.py
@@ -36,21 +36,21 @@ class VarVsEffTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             VarVsEff(np.ones(6), np.ones(6), np.ones(4), np.ones(5))
 
-    def test_var_vs_eff_init_fixed_eff_disc_cut(self):
+    def test_var_vs_eff_init_flat_eff_disc_cut(self):
         """Test var_vs_eff init."""
         with self.assertRaises(ValueError):
             VarVsEff(
                 np.ones(6),
                 np.ones(6),
-                fixed_eff_bin=True,
+                flat_eff_bin=True,
                 disc_cut=1.0,
                 working_point=0.77,
             )
 
-    def test_var_vs_eff_init_fixed_eff_no_wp(self):
+    def test_var_vs_eff_init_flat_eff_no_wp(self):
         """Test var_vs_eff init."""
         with self.assertRaises(ValueError):
-            VarVsEff(np.ones(6), np.ones(6), fixed_eff_bin=True, disc_cut=1.0)
+            VarVsEff(np.ones(6), np.ones(6), flat_eff_bin=True, disc_cut=1.0)
 
     def test_var_vs_eff_init_disc_cut_wp(self):
         """Test var_vs_eff init."""
@@ -93,7 +93,7 @@ class VarVsEffTestCase(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(var_plot.bin_edges, [-1, 1, 3], decimal=4)
 
-    def test_var_vs_eff_fixed_eff_sig_eff(self):
+    def test_var_vs_eff_flat_eff_sig_eff(self):
         """Test var_vs_eff sig_eff."""
         n_bins = 4
         var_plot = VarVsEff(
@@ -102,14 +102,14 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             bins=n_bins,
         )
         np.testing.assert_array_almost_equal(
             var_plot.sig_eff[0], [self.working_point] * n_bins, decimal=2
         )
 
-    def test_var_vs_eff_fixed_eff_sig_rej(self):
+    def test_var_vs_eff_flat_eff_sig_rej(self):
         """Test var_vs_eff sig_rej."""
         n_bins = 4
         var_plot = VarVsEff(
@@ -118,7 +118,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             bins=n_bins,
         )
         np.testing.assert_array_almost_equal(
@@ -134,7 +134,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             bins=n_bins,
         )
         var_plot_comp = VarVsEff(
@@ -171,7 +171,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             bins=n_bins,
         )
         var_plot.y_var_mean, var_plot.y_var_std = var_plot.get("sig_eff")
@@ -186,7 +186,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             bins=n_bins,
         )
         with self.assertRaises(ValueError):
@@ -200,7 +200,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             bins=1,
         )
         var_plot_comp = VarVsEff(
@@ -209,7 +209,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             bins=2,
         )
         with self.assertRaises(ValueError):
@@ -231,7 +231,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             bins=1,
         )
         mode_options = ["sig_eff", "bkg_eff", "sig_rej", "bkg_rej"]
@@ -297,8 +297,8 @@ class VarVsEffOutputTestCase(unittest.TestCase):
                 figsize=(9, 6),
             )
 
-    def test_output_plot_fixed_eff_bin_bkg_rejection(self):
-        """Test output plot with fixed eff per bin - bkg rejection."""
+    def test_output_plot_flat_eff_bin_bkg_rejection(self):
+        """Test output plot with flat eff per bin - bkg rejection."""
         # define the curves
         ref_light = VarVsEff(
             x_var_sig=self.x_var_sig_1,
@@ -308,7 +308,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             bins=self.bins,
             working_point=0.5,
             disc_cut=None,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             label="reference model",
         )
         better_light = VarVsEff(
@@ -319,7 +319,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             bins=self.bins,
             working_point=0.5,
             disc_cut=None,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             linestyle="dashed",
             label="better model (by construction better for $p_T$ > 110)",
         )
@@ -357,8 +357,8 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             ),
         )
 
-    def test_output_plot_fixed_eff_bin_bkg_efficiency(self):
-        """Test output plot with fixed eff per bin."""
+    def test_output_plot_flat_eff_bin_bkg_efficiency(self):
+        """Test output plot with flat eff per bin."""
         # define the curves
         ref_light = VarVsEff(
             x_var_sig=self.x_var_sig_1,
@@ -368,7 +368,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             bins=self.bins,
             working_point=0.5,
             disc_cut=None,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             label="reference model",
         )
         better_light = VarVsEff(
@@ -379,7 +379,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             bins=self.bins,
             working_point=0.5,
             disc_cut=None,
-            fixed_eff_bin=True,
+            flat_eff_bin=True,
             label="better model (by construction better for $p_T$ > 110)",
         )
         plot_bkg_rej = VarVsEffPlot(

--- a/puma/tests/test_var_vs_eff.py
+++ b/puma/tests/test_var_vs_eff.py
@@ -9,8 +9,8 @@ import tempfile
 import unittest
 
 import numpy as np
+from ftag import Flavours
 from matplotlib.testing.compare import compare_images
-from ftag import Flavour, Flavours
 
 from puma import VarVsEff, VarVsEffPlot
 from puma.utils.logging import logger, set_log_level
@@ -82,9 +82,6 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_sig=[0, 1, 2], disc_sig=[3, 4, 5], bins=2, working_point=0.7
         )
         np.testing.assert_array_almost_equal(var_plot.bin_edges, [0, 1, 2], decimal=4)
-
-    
-        
 
     def test_var_vs_eff_set_bin_edges(self):
         """Test var_vs_eff _set_bin_edges."""
@@ -424,48 +421,37 @@ class VarVsEffOutputTestCase(unittest.TestCase):
         )
 
     def test_var_vs_eff_info_str_fixed_eff(self):
-        
         flat_wp_plot = VarVsEffPlot(
             mode="bkg_eff",
         )
-        signal = Flavours['bjets']
+        signal = Flavours["bjets"]
 
-        flat_wp_plot.apply_modified_atlas_second_tag(
-            signal=signal,
-            working_point=0.7
-        )
+        flat_wp_plot.apply_modified_atlas_second_tag(signal=signal, working_point=0.7)
 
-        expected_tag = f"70.0% $b$-jet efficiency"
+        expected_tag = "70.0% $b$-jet efficiency"
         self.assertEqual(flat_wp_plot.atlas_second_tag, expected_tag)
+
     def test_var_vs_eff_info_str_flat_wp(self):
-        
         flat_wp_plot = VarVsEffPlot(
             mode="bkg_eff",
             atlas_second_tag="test",
         )
-        signal = Flavours['bjets']
+        signal = Flavours["bjets"]
 
         flat_wp_plot.apply_modified_atlas_second_tag(
-            signal=signal,
-            working_point=0.7,
-            flat_per_bin=True
+            signal=signal, working_point=0.7, flat_per_bin=True
         )
 
-        expected_tag = f"test\nFlat 70.0% $b$-jet efficiency per bin"
+        expected_tag = "test\nFlat 70.0% $b$-jet efficiency per bin"
         self.assertEqual(flat_wp_plot.atlas_second_tag, expected_tag)
+
     def test_var_vs_eff_info_str_fixed_disc(self):
-        
         flat_wp_plot = VarVsEffPlot(
             mode="bkg_eff",
         )
-        signal = Flavours['bjets']
+        signal = Flavours["bjets"]
 
-        flat_wp_plot.apply_modified_atlas_second_tag(
-            signal=signal,
-            disc_cut=3.0
-        )
+        flat_wp_plot.apply_modified_atlas_second_tag(signal=signal, disc_cut=3.0)
 
         expected_tag = "$D_{b}$ > 3.0"
         self.assertEqual(flat_wp_plot.atlas_second_tag, expected_tag)
-
-        

--- a/puma/tests/test_var_vs_eff.py
+++ b/puma/tests/test_var_vs_eff.py
@@ -42,7 +42,7 @@ class VarVsEffTestCase(unittest.TestCase):
             VarVsEff(
                 np.ones(6),
                 np.ones(6),
-                flat_eff_bin=True,
+                flat_per_bin=True,
                 disc_cut=1.0,
                 working_point=0.77,
             )
@@ -50,7 +50,7 @@ class VarVsEffTestCase(unittest.TestCase):
     def test_var_vs_eff_init_flat_eff_no_wp(self):
         """Test var_vs_eff init."""
         with self.assertRaises(ValueError):
-            VarVsEff(np.ones(6), np.ones(6), flat_eff_bin=True, disc_cut=1.0)
+            VarVsEff(np.ones(6), np.ones(6), flat_per_bin=True, disc_cut=1.0)
 
     def test_var_vs_eff_init_disc_cut_wp(self):
         """Test var_vs_eff init."""
@@ -102,7 +102,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             bins=n_bins,
         )
         np.testing.assert_array_almost_equal(
@@ -118,7 +118,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             bins=n_bins,
         )
         np.testing.assert_array_almost_equal(
@@ -134,7 +134,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             bins=n_bins,
         )
         var_plot_comp = VarVsEff(
@@ -171,7 +171,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             bins=n_bins,
         )
         var_plot.y_var_mean, var_plot.y_var_std = var_plot.get("sig_eff")
@@ -186,7 +186,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             bins=n_bins,
         )
         with self.assertRaises(ValueError):
@@ -200,7 +200,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             bins=1,
         )
         var_plot_comp = VarVsEff(
@@ -209,7 +209,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             bins=2,
         )
         with self.assertRaises(ValueError):
@@ -231,7 +231,7 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_bkg=self.disc_bkg,
             disc_bkg=self.x_var_bkg,
             working_point=self.working_point,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             bins=1,
         )
         mode_options = ["sig_eff", "bkg_eff", "sig_rej", "bkg_rej"]
@@ -297,7 +297,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
                 figsize=(9, 6),
             )
 
-    def test_output_plot_flat_eff_bin_bkg_rejection(self):
+    def test_output_plot_flat_per_bin_bkg_rejection(self):
         """Test output plot with flat eff per bin - bkg rejection."""
         # define the curves
         ref_light = VarVsEff(
@@ -308,7 +308,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             bins=self.bins,
             working_point=0.5,
             disc_cut=None,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             label="reference model",
         )
         better_light = VarVsEff(
@@ -319,7 +319,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             bins=self.bins,
             working_point=0.5,
             disc_cut=None,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             linestyle="dashed",
             label="better model (by construction better for $p_T$ > 110)",
         )
@@ -368,7 +368,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             bins=self.bins,
             working_point=0.5,
             disc_cut=None,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             label="reference model",
         )
         better_light = VarVsEff(
@@ -379,7 +379,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
             bins=self.bins,
             working_point=0.5,
             disc_cut=None,
-            flat_eff_bin=True,
+            flat_per_bin=True,
             label="better model (by construction better for $p_T$ > 110)",
         )
         plot_bkg_rej = VarVsEffPlot(

--- a/puma/tests/test_var_vs_eff.py
+++ b/puma/tests/test_var_vs_eff.py
@@ -10,6 +10,7 @@ import unittest
 
 import numpy as np
 from matplotlib.testing.compare import compare_images
+from ftag import Flavour, Flavours
 
 from puma import VarVsEff, VarVsEffPlot
 from puma.utils.logging import logger, set_log_level
@@ -81,6 +82,9 @@ class VarVsEffTestCase(unittest.TestCase):
             x_var_sig=[0, 1, 2], disc_sig=[3, 4, 5], bins=2, working_point=0.7
         )
         np.testing.assert_array_almost_equal(var_plot.bin_edges, [0, 1, 2], decimal=4)
+
+    
+        
 
     def test_var_vs_eff_set_bin_edges(self):
         """Test var_vs_eff _set_bin_edges."""
@@ -418,3 +422,50 @@ class VarVsEffOutputTestCase(unittest.TestCase):
                 tol=1,
             ),
         )
+
+    def test_var_vs_eff_info_str_fixed_eff(self):
+        
+        flat_wp_plot = VarVsEffPlot(
+            mode="bkg_eff",
+        )
+        signal = Flavours['bjets']
+
+        flat_wp_plot.apply_modified_atlas_second_tag(
+            signal=signal,
+            working_point=0.7
+        )
+
+        expected_tag = f"70.0% $b$-jet efficiency"
+        self.assertEqual(flat_wp_plot.atlas_second_tag, expected_tag)
+    def test_var_vs_eff_info_str_flat_wp(self):
+        
+        flat_wp_plot = VarVsEffPlot(
+            mode="bkg_eff",
+            atlas_second_tag="test",
+        )
+        signal = Flavours['bjets']
+
+        flat_wp_plot.apply_modified_atlas_second_tag(
+            signal=signal,
+            working_point=0.7,
+            flat_per_bin=True
+        )
+
+        expected_tag = f"test\nFlat 70.0% $b$-jet efficiency per bin"
+        self.assertEqual(flat_wp_plot.atlas_second_tag, expected_tag)
+    def test_var_vs_eff_info_str_fixed_disc(self):
+        
+        flat_wp_plot = VarVsEffPlot(
+            mode="bkg_eff",
+        )
+        signal = Flavours['bjets']
+
+        flat_wp_plot.apply_modified_atlas_second_tag(
+            signal=signal,
+            disc_cut=3.0
+        )
+
+        expected_tag = "$D_{b}$ > 3.0"
+        self.assertEqual(flat_wp_plot.atlas_second_tag, expected_tag)
+
+        

--- a/puma/tests/test_var_vs_var.py
+++ b/puma/tests/test_var_vs_var.py
@@ -118,11 +118,11 @@ class VarVsVarPlotTestCase(unittest.TestCase):
         # background (same for both taggers)
         self.x_var = np.linspace(0, 250, num=n_random)
         self.y_var_mean = np.exp(-self.x_var / 200) * 10
-        self.y_var_std = np.sin(self.y_var_mean)
+        self.y_var_std = np.abs(np.sin(self.y_var_mean))
         self.x_var_widths = np.ones_like(self.x_var) * 5
 
         self.y_var_mean_2 = np.exp(-self.x_var / 100) * 10
-        self.y_var_std_2 = np.sin(self.y_var_mean_2)
+        self.y_var_std_2 = np.abs(np.sin(self.y_var_mean_2))
 
         self.test = VarVsVar(
             x_var=self.x_var,

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -427,13 +427,13 @@ class VarVsEffPlot(VarVsVarPlot):  # pylint: disable=too-many-instance-attribute
                 sig_eff - Plots signal efficiency vs. variable, with statistical error
                     on N signal per bin
                 bkg_eff - Plots background efficiency vs. variable, with statistical
-                    error on N background per bin    
+                    error on N background per bin
                 sig_rej - Plots signal rejection vs. variable, with statistical error
                     on N signal per bin
                 bkg_rej - Plots background rejection vs. variable, with statistical
                     error on N background per bin
                 bkg_eff_sig_err - Plots background efficiency vs. variable, with
-                    statistical error on N signal per bin. 
+                    statistical error on N signal per bin.
         grid : bool, optional
             Set the grid for the plots.
         **kwargs : kwargs

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -465,7 +465,10 @@ class VarVsEffPlot(VarVsVarPlot):  # pylint: disable=too-many-instance-attribute
         elif disc_cut:
             mid_str = rf"$D_{{{signal.name.rstrip('jets')}}}$ > {disc_cut}"
         tag = f"Flat {mid_str} per bin" if flat_per_bin else f"{mid_str}"
-        self.atlas_second_tag = f"{self.atlas_second_tag}\n{tag}"
+        if self.atlas_second_tag:
+            self.atlas_second_tag = f"{self.atlas_second_tag}\n{tag}"
+        else:
+            self.atlas_second_tag = tag
 
     def plot(self, **kwargs):
         """Plotting curves.

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -1,6 +1,8 @@
 """Efficiency plots vs. specific variable."""
 from __future__ import annotations
 
+from typing import ClassVar
+
 import numpy as np
 
 # TODO: fix the import below
@@ -26,7 +28,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         working_point: float | None = None,
         disc_cut=None,
         flat_per_bin: bool = False,
-        key: str = None,
+        key: str | None = None,
         **kwargs,
     ) -> None:
         """Initialise properties of roc curve object.
@@ -264,7 +266,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
             return np.nan, np.nan
         rej_error = rej_err(rej, len(arr))
         return rej, rej_error
-    
+
     @property
     def bkg_eff_sig_err(self):
         """Calculate signal efficiency per bin, assuming a flat background per
@@ -272,11 +274,14 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         background error per bin.
         """
         logger.debug("Calculating signal efficiency.")
-        eff = np.array(list(map(self.efficiency, self.disc_binned_bkg, self.disc_cut)))[:,0]
-        err = np.array(list(map(self.efficiency, self.disc_binned_sig, self.disc_cut)))[:,1]
+        eff = np.array(list(map(self.efficiency, self.disc_binned_bkg, self.disc_cut)))[
+            :, 0
+        ]
+        err = np.array(list(map(self.efficiency, self.disc_binned_sig, self.disc_cut)))[
+            :, 1
+        ]
         logger.debug("Retrieved signal efficiencies: %s", eff)
         return eff, err
-
 
     @property
     def sig_eff(self):
@@ -363,7 +368,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         Parameters
         ----------
         mode : str
-            Can be "sig_eff", "bkg_eff", "sig_rej", "bkg_rej", or 
+            Can be "sig_eff", "bkg_eff", "sig_rej", "bkg_rej", or
             "bkg_eff_sig_err"
         inverse_cut : bool, optional
             Inverts the discriminant cut, which will yield the efficiency or rejection
@@ -381,7 +386,6 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         ValueError
             If mode not supported
         """
-        
         self.inverse_cut = inverse_cut
         # TODO: python 3.10 switch to cases syntax
         if mode == "sig_eff":
@@ -405,8 +409,13 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
 class VarVsEffPlot(VarVsVarPlot):  # pylint: disable=too-many-instance-attributes
     """var_vs_eff plot class"""
 
-    mode_options = ["sig_eff", "bkg_eff", "sig_rej", "bkg_rej",
-                    "bkg_eff_sig_err"]
+    mode_options: ClassVar[list[str]] = [
+        "sig_eff",
+        "bkg_eff",
+        "sig_rej",
+        "bkg_rej",
+        "bkg_eff_sig_err",
+    ]
 
     def __init__(self, mode, grid: bool = False, **kwargs) -> None:
         """var_vs_eff plot properties.

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -424,7 +424,16 @@ class VarVsEffPlot(VarVsVarPlot):  # pylint: disable=too-many-instance-attribute
         ----------
         mode : str
             Defines which quantity is plotted, the following options ar available:
-            "sig_eff", "bkg_eff", "sig_rej", "bkg_rej", or "bkg_eff_sig_err"
+                sig_eff - Plots signal efficiency vs. variable, with statistical error
+                    on N signal per bin
+                bkg_eff - Plots background efficiency vs. variable, with statistical
+                    error on N background per bin    
+                sig_rej - Plots signal rejection vs. variable, with statistical error
+                    on N signal per bin
+                bkg_rej - Plots background rejection vs. variable, with statistical
+                    error on N background per bin
+                bkg_eff_sig_err - Plots background efficiency vs. variable, with
+                    statistical error on N signal per bin. 
         grid : bool, optional
             Set the grid for the plots.
         **kwargs : kwargs

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -23,7 +23,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         bins=10,
         working_point: float = None,
         disc_cut=None,
-        flat_eff_bin: bool = False,
+        flat_per_bin: bool = False,
         key: str = None,
         **kwargs,
     ) -> None:
@@ -49,7 +49,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         disc_cut : float or  sequence of floats, optional
             Cut value for discriminant, if it is a sequence it has to have the same
             length as number of bins, by default None
-        flat_eff_bin : bool, optional
+        flat_per_bin : bool, optional
             If True and no `disc_cut` is given the signal efficiency is held constant
             in each bin, by default False
         key : str, optional
@@ -79,14 +79,14 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         # the arguments to init e.g. `set_method`
         if working_point is None and disc_cut is None:
             raise ValueError("Either `wp` or `disc_cut` needs to be specified.")
-        if flat_eff_bin:
+        if flat_per_bin:
             if disc_cut is not None:
                 raise ValueError(
-                    "You cannot specify `disc_cut` when `flat_eff_bin` is set to True."
+                    "You cannot specify `disc_cut` when `flat_per_bin` is set to True."
                 )
             if working_point is None:
                 raise ValueError(
-                    "You need to specify a working point `wp`, when `flat_eff_bin` is"
+                    "You need to specify a working point `wp`, when `flat_per_bin` is"
                     " set to True."
                 )
         self.x_var_sig = np.array(x_var_sig)
@@ -95,7 +95,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         self.disc_bkg = None if disc_bkg is None else np.array(disc_bkg)
         self.working_point = working_point
         self.disc_cut = disc_cut
-        self.flat_eff_bin = flat_eff_bin
+        self.flat_per_bin = flat_per_bin
         # Binning related variables
         self.n_bins = None
         self.bn_edges = None
@@ -200,7 +200,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
             self.disc_cut = [self.disc_cut] * self.n_bins
         elif isinstance(self.disc_cut, (list, np.ndarray)):
             self.disc_cut = self.disc_cut
-        elif self.flat_eff_bin:
+        elif self.flat_per_bin:
             self.disc_cut = list(
                 map(
                     lambda x: np.percentile(x, (1 - self.working_point) * 100),
@@ -337,7 +337,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
                 and np.all(self.bn_edges == other.bn_edges)
                 and self.working_point == other.working_point
                 and np.all(self.disc_cut == other.disc_cut)
-                and self.flat_eff_bin == other.flat_eff_bin
+                and self.flat_per_bin == other.flat_per_bin
                 and self.key == other.key
             )
         return False

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -421,6 +421,19 @@ class VarVsEffPlot(VarVsVarPlot):  # pylint: disable=too-many-instance-attribute
             elem.y_var_mean = y_value
             elem.y_var_std = y_error
 
+    def apply_modified_atlas_second_tag(self, flavour):
+        '''Modifies the atlas_second_tag to include info on the type of p-eff plot
+        being displayed
+        '''
+        if self.mode == 'sig_eff':
+            self.atlas_second_tag = f'{self.atlas_second_tag} {flavour} p-eff'
+        elif self.mode == 'bkg_eff':
+            self.atlas_second_tag = f'{self.atlas_second_tag} {flavour} b-eff'
+        elif self.mode == 'sig_rej':
+            self.atlas_second_tag = f'{self.atlas_second_tag} {flavour} p-rej'
+        elif self.mode == 'bkg_rej':
+            self.atlas_second_tag = f'{self.atlas_second_tag} {flavour} b-rej'
+
     def plot(self, **kwargs):
         """Plotting curves.
 

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -422,25 +422,22 @@ class VarVsEffPlot(VarVsVarPlot):  # pylint: disable=too-many-instance-attribute
             elem.y_var_std = y_error
 
     def apply_modified_atlas_second_tag(
-            self, 
-            signal,
-            working_point=None,
-            disc_cut=None,
-            flat_per_bin=False,):
-        '''Modifies the atlas_second_tag to include info on the type of p-eff plot
+        self,
+        signal,
+        working_point=None,
+        disc_cut=None,
+        flat_per_bin=False,
+    ):
+        """Modifies the atlas_second_tag to include info on the type of p-eff plot
         being displayed
-        '''
-        
+        """
         if working_point:
-            mid_str = f"{round(working_point*100, 3)}% "+ signal.eff_str
+            mid_str = f"{round(working_point*100, 3)}% " + signal.eff_str
         elif disc_cut:
             mid_str = rf"$D_{{{signal.name.rstrip('jets')}}}$ > {disc_cut}"
-        if flat_per_bin:
-            tag = f"Flat {mid_str} per bin"
-        else:
-            tag = f"{mid_str}"
+        tag = f"Flat {mid_str} per bin" if flat_per_bin else f"{mid_str}"
         self.atlas_second_tag = f"{self.atlas_second_tag}\n{tag}"
-            
+
     def plot(self, **kwargs):
         """Plotting curves.
 

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -23,7 +23,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         bins=10,
         working_point: float = None,
         disc_cut=None,
-        fixed_eff_bin: bool = False,
+        flat_eff_bin: bool = False,
         key: str = None,
         **kwargs,
     ) -> None:
@@ -49,7 +49,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         disc_cut : float or  sequence of floats, optional
             Cut value for discriminant, if it is a sequence it has to have the same
             length as number of bins, by default None
-        fixed_eff_bin : bool, optional
+        flat_eff_bin : bool, optional
             If True and no `disc_cut` is given the signal efficiency is held constant
             in each bin, by default False
         key : str, optional
@@ -79,14 +79,14 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         # the arguments to init e.g. `set_method`
         if working_point is None and disc_cut is None:
             raise ValueError("Either `wp` or `disc_cut` needs to be specified.")
-        if fixed_eff_bin:
+        if flat_eff_bin:
             if disc_cut is not None:
                 raise ValueError(
-                    "You cannot specify `disc_cut` when `fixed_eff_bin` is set to True."
+                    "You cannot specify `disc_cut` when `flat_eff_bin` is set to True."
                 )
             if working_point is None:
                 raise ValueError(
-                    "You need to specify a working point `wp`, when `fixed_eff_bin` is"
+                    "You need to specify a working point `wp`, when `flat_eff_bin` is"
                     " set to True."
                 )
         self.x_var_sig = np.array(x_var_sig)
@@ -95,7 +95,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         self.disc_bkg = None if disc_bkg is None else np.array(disc_bkg)
         self.working_point = working_point
         self.disc_cut = disc_cut
-        self.fixed_eff_bin = fixed_eff_bin
+        self.flat_eff_bin = flat_eff_bin
         # Binning related variables
         self.n_bins = None
         self.bn_edges = None
@@ -200,7 +200,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
             self.disc_cut = [self.disc_cut] * self.n_bins
         elif isinstance(self.disc_cut, (list, np.ndarray)):
             self.disc_cut = self.disc_cut
-        elif self.fixed_eff_bin:
+        elif self.flat_eff_bin:
             self.disc_cut = list(
                 map(
                     lambda x: np.percentile(x, (1 - self.working_point) * 100),
@@ -337,7 +337,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
                 and np.all(self.bn_edges == other.bn_edges)
                 and self.working_point == other.working_point
                 and np.all(self.disc_cut == other.disc_cut)
-                and self.fixed_eff_bin == other.fixed_eff_bin
+                and self.flat_eff_bin == other.flat_eff_bin
                 and self.key == other.key
             )
         return False

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -421,19 +421,26 @@ class VarVsEffPlot(VarVsVarPlot):  # pylint: disable=too-many-instance-attribute
             elem.y_var_mean = y_value
             elem.y_var_std = y_error
 
-    def apply_modified_atlas_second_tag(self, flavour):
+    def apply_modified_atlas_second_tag(
+            self, 
+            signal,
+            working_point=None,
+            disc_cut=None,
+            flat_per_bin=False,):
         '''Modifies the atlas_second_tag to include info on the type of p-eff plot
         being displayed
         '''
-        if self.mode == 'sig_eff':
-            self.atlas_second_tag = f'{self.atlas_second_tag} {flavour} p-eff'
-        elif self.mode == 'bkg_eff':
-            self.atlas_second_tag = f'{self.atlas_second_tag} {flavour} b-eff'
-        elif self.mode == 'sig_rej':
-            self.atlas_second_tag = f'{self.atlas_second_tag} {flavour} p-rej'
-        elif self.mode == 'bkg_rej':
-            self.atlas_second_tag = f'{self.atlas_second_tag} {flavour} b-rej'
-
+        
+        if working_point:
+            mid_str = f"{round(working_point*100, 3)}% "+ signal.eff_str
+        elif disc_cut:
+            mid_str = rf"$D_{{{signal.name.rstrip('jets')}}}$ > {disc_cut}"
+        if flat_per_bin:
+            tag = f"Flat {mid_str} per bin"
+        else:
+            tag = f"{mid_str}"
+        self.atlas_second_tag = f"{self.atlas_second_tag}\n{tag}"
+            
     def plot(self, **kwargs):
         """Plotting curves.
 

--- a/puma/var_vs_eff.py
+++ b/puma/var_vs_eff.py
@@ -396,7 +396,7 @@ class VarVsEff(VarVsVar):  # pylint: disable=too-many-instance-attributes
         self.inverse_cut = False
         raise ValueError(
             f"The selected mode {mode} is not supported. Use one of the following:"
-            f" {self.mode_options}."
+            f" {VarVsEffPlot.mode_options}."
         )
 
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Rename the default outputs for 'peff' plots, to be more clear
* Renamed argument for peff plots 'fixed_eff_bin' -> 'flat_eff_bin' to reduce confusion between 'fixed WP' and 'flat efficiency'
* Introduce support in high-level API for plotting signal efficiency as a function of a variable, for a fixed background rejection per bin.


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
