### PR TITLE
Add NaN filtering for HL plots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Add NaN filtering for HL plots [!220](https://github.com/umami-hep/puma/pull/220)
 - Making Under- and Overflow bins default in histograms [!218](https://github.com/umami-hep/puma/pull/218)
 
 ### [v0.3.0] (2023/10/03)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Add NaN filtering for HL plots [!220](https://github.com/umami-hep/puma/pull/220)
+- Add NaN filtering for HL plots. Bump atlas-ftag-tools version to 0.1.11. [!220](https://github.com/umami-hep/puma/pull/220)
 - Making Under- and Overflow bins default in histograms [!218](https://github.com/umami-hep/puma/pull/218)
 
 ### [v0.3.0] (2023/10/03)

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 from ftag import get_mock_file
+from ftag.hdf5 import structured_from_dict
 from matplotlib.testing.compare import compare_images
 
 from puma.hlplots import Results
@@ -72,26 +73,6 @@ class ResultsTestCase(unittest.TestCase):
         results.add_taggers_from_file(taggers, fname, cuts=cuts)
         self.assertEqual(list(results.taggers.values()), taggers)
 
-    # TODO: delete this when we bump the tools version
-    def structured_from_dict(self, d: dict[str, np.ndarray]) -> np.ndarray:
-        """Convert a dict to a structured array.
-
-        Parameters
-        ----------
-        d : dict
-            Input dict of numpy arrays
-
-        Returns
-        -------
-        np.ndarray
-            Structured array
-        """
-        from numpy.lib.recfunctions import unstructured_to_structured as u2s
-
-        arrays = np.column_stack(list(d.values()))
-        dtypes = np.dtype([(k, v.dtype) for k, v in d.items()])
-        return u2s(arrays, dtype=dtypes)
-
     def test_add_taggers_hbb(self):
         # get mock file and rename variables match hbb
         f = get_mock_file()[1]
@@ -102,7 +83,7 @@ class ResultsTestCase(unittest.TestCase):
         d["MockTagger_ptop"] = f["jets"]["MockTagger_pu"]
         d["MockTagger_pqcd"] = f["jets"]["MockTagger_pu"]
         d["pt"] = f["jets"]["pt"]
-        array = self.structured_from_dict(d)
+        array = structured_from_dict(d)
         with tempfile.TemporaryDirectory() as tmp_file:
             fname = Path(tmp_file) / "test.h5"
             with h5py.File(fname, "w") as f:
@@ -124,7 +105,7 @@ class ResultsTestCase(unittest.TestCase):
         d["pt"] = f["jets"]["pt"]
         n_nans = np.random.choice(range(100), 10)
         d["MockTagger_pb"][n_nans] = np.nan
-        array = self.structured_from_dict(d)
+        array = structured_from_dict(d)
         with tempfile.TemporaryDirectory() as tmp_file:
             fname = Path(tmp_file) / "test.h5"
             with h5py.File(fname, "w") as f:
@@ -143,9 +124,9 @@ class ResultsTestCase(unittest.TestCase):
         d["MockTagger_pc"] = f["jets"]["MockTagger_pc"]
         d["MockTagger_pu"] = f["jets"]["MockTagger_pu"]
         d["pt"] = f["jets"]["pt"]
-        n_nans = np.random.choice(range(100), 10)
+        n_nans = np.random.choice(range(100), 10, replace=False)
         d["MockTagger_pb"][n_nans] = np.nan
-        array = self.structured_from_dict(d)
+        array = structured_from_dict(d)
         with tempfile.TemporaryDirectory() as tmp_file:
             fname = Path(tmp_file) / "test.h5"
             with h5py.File(fname, "w") as f:

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -72,27 +72,27 @@ class ResultsTestCase(unittest.TestCase):
         results.add_taggers_from_file(taggers, fname, cuts=cuts)
         self.assertEqual(list(results.taggers.values()), taggers)
 
+    # TODO: delete this when we bump the tools version
+    def structured_from_dict(self, d: dict[str, np.ndarray]) -> np.ndarray:
+        """Convert a dict to a structured array.
+
+        Parameters
+        ----------
+        d : dict
+            Input dict of numpy arrays
+
+        Returns
+        -------
+        np.ndarray
+            Structured array
+        """
+        from numpy.lib.recfunctions import unstructured_to_structured as u2s
+
+        arrays = np.column_stack(list(d.values()))
+        dtypes = np.dtype([(k, v.dtype) for k, v in d.items()])
+        return u2s(arrays, dtype=dtypes)
+
     def test_add_taggers_hbb(self):
-        # TODO: delete this when we bump the tools version
-        def structured_from_dict(d: dict[str, np.ndarray]) -> np.ndarray:
-            """Convert a dict to a structured array.
-
-            Parameters
-            ----------
-            d : dict
-                Input dict of numpy arrays
-
-            Returns
-            -------
-            np.ndarray
-                Structured array
-            """
-            from numpy.lib.recfunctions import unstructured_to_structured as u2s
-
-            arrays = np.column_stack(list(d.values()))
-            dtypes = np.dtype([(k, v.dtype) for k, v in d.items()])
-            return u2s(arrays, dtype=dtypes)
-
         # get mock file and rename variables match hbb
         f = get_mock_file()[1]
         d = {}
@@ -102,7 +102,7 @@ class ResultsTestCase(unittest.TestCase):
         d["MockTagger_ptop"] = f["jets"]["MockTagger_pu"]
         d["MockTagger_pqcd"] = f["jets"]["MockTagger_pu"]
         d["pt"] = f["jets"]["pt"]
-        array = structured_from_dict(d)
+        array = self.structured_from_dict(d)
         with tempfile.TemporaryDirectory() as tmp_file:
             fname = Path(tmp_file) / "test.h5"
             with h5py.File(fname, "w") as f:
@@ -113,27 +113,8 @@ class ResultsTestCase(unittest.TestCase):
                 [Tagger("MockTagger")], fname, label_var="R10TruthLabel"
             )
 
-    def test_add_taggers_nan(self):
-        def structured_from_dict(d: dict[str, np.ndarray]) -> np.ndarray:
-            """Convert a dict to a structured array.
-
-            Parameters
-            ----------
-            d : dict
-                Input dict of numpy arrays
-
-            Returns
-            -------
-            np.ndarray
-                Structured array
-            """
-            from numpy.lib.recfunctions import unstructured_to_structured as u2s
-
-            arrays = np.column_stack(list(d.values()))
-            dtypes = np.dtype([(k, v.dtype) for k, v in d.items()])
-            return u2s(arrays, dtype=dtypes)
-
-        # get mock file and rename variables match hbb
+    def test_add_taggers_keep_nan(self):
+        # get mock file and add nans
         f = get_mock_file()[1]
         d = {}
         d["HadronConeExclTruthLabelID"] = f["jets"]["HadronConeExclTruthLabelID"]
@@ -143,18 +124,42 @@ class ResultsTestCase(unittest.TestCase):
         d["pt"] = f["jets"]["pt"]
         n_nans = np.random.choice(range(100), 10)
         d["MockTagger_pb"][n_nans] = np.nan
-        array = structured_from_dict(d)
+        array = self.structured_from_dict(d)
         with tempfile.TemporaryDirectory() as tmp_file:
             fname = Path(tmp_file) / "test.h5"
             with h5py.File(fname, "w") as f:
                 f.create_dataset("jets", data=array)
 
-            results = Results(signal="bjets", sample="test")
+            results = Results(signal="bjets", sample="test", remove_nan=False)
+            with self.assertRaises(ValueError):
+                results.add_taggers_from_file([Tagger("MockTagger")], fname)
+
+    def test_add_taggers_remove_nan(self):
+        # get mock file and add nans
+        f = get_mock_file()[1]
+        d = {}
+        d["HadronConeExclTruthLabelID"] = f["jets"]["HadronConeExclTruthLabelID"]
+        d["MockTagger_pb"] = f["jets"]["MockTagger_pb"]
+        d["MockTagger_pc"] = f["jets"]["MockTagger_pc"]
+        d["MockTagger_pu"] = f["jets"]["MockTagger_pu"]
+        d["pt"] = f["jets"]["pt"]
+        n_nans = np.random.choice(range(100), 10)
+        d["MockTagger_pb"][n_nans] = np.nan
+        array = self.structured_from_dict(d)
+        with tempfile.TemporaryDirectory() as tmp_file:
+            fname = Path(tmp_file) / "test.h5"
+            with h5py.File(fname, "w") as f:
+                f.create_dataset("jets", data=array)
+
+            results = Results(signal="bjets", sample="test", remove_nan=True)
             with self.assertLogs("puma", "WARNING") as cm:
                 results.add_taggers_from_file([Tagger("MockTagger")], fname)
             self.assertEqual(
                 cm.output,
-                [f"WARNING:puma:{len(n_nans)} NaN values found in loaded data."],
+                [
+                    f"WARNING:puma:{len(n_nans)} NaN values found in loaded data."
+                    " Removing them."
+                ],
             )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ scipy==1.10.1
 tables==3.7.0
 testfixtures==7.0.0
 palettable==3.3.0
-atlas-ftag-tools==0.1.9
+atlas-ftag-tools==0.1.11


### PR DESCRIPTION
## Summary

This pull request introduces the following changes.

* Add NaN filtering to the loaded data in HL plots and warn the user about it.
* Update `atlas-ftag-tools` package

Relates to the following issues

* #219 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
