### PR TITLE
Draft: modify top label in Xbb and add catch for legacy tagger plotting

### DIFF
--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -80,6 +80,27 @@ class ResultsTestCase(unittest.TestCase):
         d["R10TruthLabel"] = f["jets"]["HadronConeExclTruthLabelID"]
         d["MockTagger_phbb"] = f["jets"]["MockTagger_pb"]
         d["MockTagger_phcc"] = f["jets"]["MockTagger_pc"]
+        d["MockTagger_ptqqb"] = f["jets"]["MockTagger_pu"]
+        d["MockTagger_pqcd"] = f["jets"]["MockTagger_pu"]
+        d["pt"] = f["jets"]["pt"]
+        array = structured_from_dict(d)
+        with tempfile.TemporaryDirectory() as tmp_file:
+            fname = Path(tmp_file) / "test.h5"
+            with h5py.File(fname, "w") as f:
+                f.create_dataset("jets", data=array)
+
+            results = Results(signal="hbb", sample="test")
+            results.add_taggers_from_file(
+                [Tagger("MockTagger")], fname, label_var="R10TruthLabel"
+            )
+
+    def test_add_taggers_hbb_legacy(self):
+        # get mock file and rename variables match hbb
+        f = get_mock_file()[1]
+        d = {}
+        d["R10TruthLabel"] = f["jets"]["HadronConeExclTruthLabelID"]
+        d["MockTagger_phbb"] = f["jets"]["MockTagger_pb"]
+        d["MockTagger_phcc"] = f["jets"]["MockTagger_pc"]
         d["MockTagger_ptop"] = f["jets"]["MockTagger_pu"]
         d["MockTagger_pqcd"] = f["jets"]["MockTagger_pu"]
         d["pt"] = f["jets"]["pt"]

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -175,14 +175,14 @@ class TaggerTestCase(unittest.TestCase):
         from ftag import Flavours as F
 
         tagger = Tagger(
-            "dummy", output_flavours=[F["hbb"], F["hcc"], F["top"], F["qcd"]]
+            "dummy", output_flavours=[F["hbb"], F["hcc"], F["tqqb"], F["qcd"]]
         )
         tagger.scores = u2s(
             np.column_stack((np.ones(10), np.ones(10), np.ones(10), np.ones(10))),
             dtype=[
                 ("dummy_phbb", "f4"),
                 ("dummy_phcc", "f4"),
-                ("dummy_ptop", "f4"),
+                ("dummy_ptqqb", "f4"),
                 ("dummy_pqcd", "f4"),
             ],
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ scipy==1.10.1
 tables==3.7.0
 testfixtures==7.0.0
 palettable==3.3.0
-atlas-ftag-tools==0.1.11
+atlas-ftag-tools==0.1.12


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* modify the Xbb label in the high level plotting interface from `top` to `tqqb`.
* add `try` / `except` block to catch cases where legacy configurations are plotted


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
