### PR TITLE
metric.weighted_percentile fixing bug connected to range of a float

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Extended usable range for metrics.weighted_percentile with double precision [!231](https://github.com/umami-hep/puma/pull/231)
 - Consistent fc scan colours [!228](https://github.com/umami-hep/puma/pull/228)
 - Add tools for plotting vertexing performance. [!216](https://github.com/umami-hep/puma/pull/216) 
 

--- a/puma/metrics.py
+++ b/puma/metrics.py
@@ -33,12 +33,14 @@ def weighted_percentile(
     """
     if weights is None:
         weights = np.ones_like(data)
+    dtype = np.float64 if np.sum(weights) > 1000000 else np.float32
     ix = np.argsort(data)
     data = data[ix]  # sort data
     weights = weights[ix]  # sort weights
-    cdf = np.cumsum(weights) - 0.5 * weights
+    cdf = np.cumsum(weights, dtype=dtype) - 0.5 * weights
     cdf -= cdf[0]
-    return np.interp(perc*cdf[-1], cdf, data)
+    cdf /= cdf[-1]
+    return np.interp(perc, cdf, data)
 
 
 def calc_eff(

--- a/puma/metrics.py
+++ b/puma/metrics.py
@@ -38,8 +38,7 @@ def weighted_percentile(
     weights = weights[ix]  # sort weights
     cdf = np.cumsum(weights) - 0.5 * weights
     cdf -= cdf[0]
-    cdf /= cdf[-1]
-    return np.interp(perc, cdf, data)
+    return np.interp(perc*cdf[-1], cdf, data)
 
 
 def calc_eff(


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

Before that the cdf had n_data values ususally equidistantly spread in [0, 1] region which leads to a lot of problems with float arythmetic if n_data is around or greater 1_000_000 (empirically). I let the range be extended by casting data into floaat64

Relates to the following issues

* Solves https://github.com/umami-hep/puma/issues/230

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
