### PR TITLE
Add multiple perf_vars support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### [Latest]
+
+- Add support for multiple perf_vars in HLAPI [!233](https://github.com/umami-hep/puma/pull/233)
 - Remove scipy dependency [!232](https://github.com/umami-hep/puma/pull/232)
 - Extended usable range for metrics.weighted_percentile with double precision [!231](https://github.com/umami-hep/puma/pull/231)
 - Consistent fc scan colours [!228](https://github.com/umami-hep/puma/pull/228)

--- a/puma/hlplots/tagger.py
+++ b/puma/hlplots/tagger.py
@@ -29,7 +29,7 @@ class Tagger:
     # commonly set by the Results class
     scores: np.ndarray = None
     labels: np.ndarray = None
-    perf_var: np.ndarray = None
+    perf_vars: dict = None
     aux_metrics: dict = None
     output_flavours: list = field(
         default_factory=lambda: [Flavours.ujets, Flavours.cjets, Flavours.bjets]

--- a/puma/tests/hlplots/test_aux_results.py
+++ b/puma/tests/hlplots/test_aux_results.py
@@ -22,7 +22,6 @@ class AuxResultsTestCase(unittest.TestCase):
 
     def test_add_taggers_from_file(self):
         """Test for Results.add_taggers_from_file function."""
-        np.random.default_rng(seed=16)
         fname = get_mock_file()[0]
         results = AuxResults(signal="bjets", sample="test")
         taggers = [Tagger("MockTagger")]
@@ -35,7 +34,6 @@ class AuxResultsTestCase(unittest.TestCase):
         self.assertEqual(list(results.taggers.values()), taggers)
 
     def test_add_taggers_with_cuts(self):
-        np.random.default_rng(seed=16)
         fname = get_mock_file()[0]
         cuts = [("eta", ">", 0)]
         tagger_cuts = [("pt", ">", 20)]
@@ -47,6 +45,26 @@ class AuxResultsTestCase(unittest.TestCase):
             vtx_label_var="numberOfPixelHits",
             vtx_reco_var="numberOfSCTHits",
             cuts=cuts,
+        )
+        self.assertEqual(list(results.taggers.values()), taggers)
+
+    def test_add_taggers_with_cuts_override_perf_vars(self):
+        rng = np.random.default_rng(seed=16)
+        fname = get_mock_file()[0]
+        cuts = [("eta", ">", 0)]
+        tagger_cuts = [("pt", ">", 20)]
+        results = AuxResults(signal="bjets", sample="test")
+        taggers = [Tagger("MockTagger", cuts=tagger_cuts)]
+        results.add_taggers_from_file(
+            taggers,
+            fname,
+            vtx_label_var="numberOfPixelHits",
+            vtx_reco_var="numberOfSCTHits",
+            cuts=cuts,
+            perf_vars={
+                "pt": rng.exponential(100, size=1000),
+                "eta": rng.normal(0, 1, size=1000),
+            },
         )
         self.assertEqual(list(results.taggers.values()), taggers)
 

--- a/puma/tests/hlplots/test_aux_results.py
+++ b/puma/tests/hlplots/test_aux_results.py
@@ -66,7 +66,7 @@ class AuxResultsPlotsTestCase(unittest.TestCase):
             f["tracks"]["numberOfPixelHits"],
             f["tracks"]["numberOfSCTHits"],
         )
-        dummy_tagger_1.perf_var = f["jets"]["pt"]
+        dummy_tagger_1.perf_vars = {"pt": f["jets"]["pt"]}
         dummy_tagger_1.scores = f["jets"]
         dummy_tagger_1.label = "dummy tagger"
         self.dummy_tagger_1 = dummy_tagger_1

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -56,11 +56,37 @@ class ResultsTestCase(unittest.TestCase):
 
     def test_add_taggers_from_file(self):
         """Test for Results.add_taggers_from_file function."""
-        np.random.default_rng(seed=16)
         fname = get_mock_file()[0]
         results = Results(signal="bjets", sample="test")
         taggers = [Tagger("MockTagger")]
         results.add_taggers_from_file(taggers, fname)
+        self.assertEqual(list(results.taggers.values()), taggers)
+
+    def test_add_taggers_from_file_with_perf_vars(self):
+        """Test for Results.add_taggers_from_file function."""
+        fname = get_mock_file()[0]
+        results = Results(signal="bjets", sample="test", perf_vars=["pt", "eta"])
+        taggers = [Tagger("MockTagger")]
+        results.add_taggers_from_file(taggers, fname)
+        self.assertEqual(list(results.taggers.values()), taggers)
+
+    def test_add_taggers_with_cuts_override_perf_vars(self):
+        """Test for Results.add_taggers_from_file function."""
+        rng = np.random.default_rng(seed=16)
+        cuts = [("eta", ">", 0)]
+        tagger_cuts = [("pt", ">", 20)]
+        fname = get_mock_file(num_jets=1000)[0]
+        results = Results(signal="bjets", sample="test", perf_vars=["pt", "eta"])
+        taggers = [Tagger("MockTagger", cuts=tagger_cuts)]
+        results.add_taggers_from_file(
+            taggers,
+            fname,
+            cuts=cuts,
+            perf_vars={
+                "pt": rng.exponential(100, size=1000),
+                "eta": rng.normal(0, 1, size=1000),
+            },
+        )
         self.assertEqual(list(results.taggers.values()), taggers)
 
     def test_add_taggers_with_cuts(self):
@@ -237,9 +263,9 @@ class ResultsPlotsTestCase(unittest.TestCase):
         self.dummy_tagger_1.f_c = 0.05
         self.dummy_tagger_1.disc_cut = 2
         rng = np.random.default_rng(seed=16)
-        self.dummy_tagger_1.perf_var = rng.exponential(
-            100, size=len(self.dummy_tagger_1.scores)
-        )
+        self.dummy_tagger_1.perf_vars = {
+            "pt": rng.exponential(100, size=len(self.dummy_tagger_1.scores))
+        }
         with tempfile.TemporaryDirectory() as tmp_file:
             results = Results(signal="bjets", sample="test", output_dir=tmp_file)
             results.add(self.dummy_tagger_1)
@@ -262,9 +288,9 @@ class ResultsPlotsTestCase(unittest.TestCase):
         self.dummy_tagger_1.f_c = 0.05
         self.dummy_tagger_1.disc_cut = 2
         rng = np.random.default_rng(seed=16)
-        self.dummy_tagger_1.perf_var = rng.exponential(
-            100, size=len(self.dummy_tagger_1.scores)
-        )
+        self.dummy_tagger_1.perf_vars = {
+            "pt": rng.exponential(100, size=len(self.dummy_tagger_1.scores))
+        }
         with tempfile.TemporaryDirectory() as tmp_file:
             with self.assertRaises(ValueError):
                 results = Results(signal="bjets", sample="test", output_dir=tmp_file)
@@ -285,9 +311,9 @@ class ResultsPlotsTestCase(unittest.TestCase):
         self.dummy_tagger_1.f_c = 0.05
         self.dummy_tagger_1.disc_cut = 2
         rng = np.random.default_rng(seed=16)
-        self.dummy_tagger_1.perf_var = rng.exponential(
-            100, size=len(self.dummy_tagger_1.scores)
-        )
+        self.dummy_tagger_1.perf_vars = {
+            "pt": rng.exponential(100, size=len(self.dummy_tagger_1.scores))
+        }
         with tempfile.TemporaryDirectory() as tmp_file:
             results = Results(signal="bjets", sample="test", output_dir=tmp_file)
             results.add(self.dummy_tagger_1)
@@ -306,15 +332,57 @@ class ResultsPlotsTestCase(unittest.TestCase):
                 Path(tmp_file) / "test_bjets_ujets_rej_vs_pt_profile_fixed_cut_.png"
             )
 
+    def test_plot_var_perf_multi_bjets(self):
+        """Test that png file is being created."""
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.f_c = 0.05
+        self.dummy_tagger_1.disc_cut = 2
+        rng = np.random.default_rng(seed=16)
+        self.dummy_tagger_1.perf_vars = {
+            "pt": rng.exponential(100, size=len(self.dummy_tagger_1.scores)),
+            "eta": rng.normal(0, 1, size=len(self.dummy_tagger_1.scores)),
+        }
+        with tempfile.TemporaryDirectory() as tmp_file:
+            results = Results(signal="bjets", sample="test", output_dir=tmp_file)
+            results.add(self.dummy_tagger_1)
+            results.plot_var_perf(
+                bins=[20, 30, 40, 60, 85, 110, 140, 175, 250],
+                working_point=0.7,
+                perf_var="pt",
+            )
+            results.plot_var_perf(
+                bins=np.linspace(-0.5, 0.5, 10), working_point=0.7, perf_var="eta"
+            )
+
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_bjets_eff_vs_pt_profile_fixed_cut_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_cjets_rej_vs_pt_profile_fixed_cut_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_ujets_rej_vs_pt_profile_fixed_cut_.png"
+            )
+
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_bjets_eff_vs_eta_profile_fixed_cut_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_cjets_rej_vs_eta_profile_fixed_cut_.png"
+            )
+            self.assertIsFile(
+                Path(tmp_file) / "test_bjets_ujets_rej_vs_eta_profile_fixed_cut_.png"
+            )
+
     def test_plot_var_perf_cjets(self):
         """Test that png file is being created."""
         self.dummy_tagger_1.reference = True
         self.dummy_tagger_1.f_b = 0.05
         self.dummy_tagger_1.working_point = 0.5
         rng = np.random.default_rng(seed=16)
-        self.dummy_tagger_1.perf_var = rng.exponential(
-            100, size=len(self.dummy_tagger_1.scores)
-        )
+        self.dummy_tagger_1.perf_vars = {
+            "pt": rng.exponential(100, size=len(self.dummy_tagger_1.scores))
+        }
         with tempfile.TemporaryDirectory() as tmp_file:
             results = Results(signal="cjets", sample="test", output_dir=tmp_file)
             results.add(self.dummy_tagger_1)
@@ -338,9 +406,9 @@ class ResultsPlotsTestCase(unittest.TestCase):
         self.dummy_tagger_1.f_c = 0.05
         self.dummy_tagger_1.working_point = 0.5
         rng = np.random.default_rng(seed=16)
-        self.dummy_tagger_1.perf_var = rng.exponential(
-            100, size=len(self.dummy_tagger_1.scores)
-        )
+        self.dummy_tagger_1.perf_vars = {
+            "pt": rng.exponential(100, size=len(self.dummy_tagger_1.scores))
+        }
         with tempfile.TemporaryDirectory() as tmp_file:
             results = Results(signal="bjets", sample="test", output_dir=tmp_file)
             results.add(self.dummy_tagger_1)
@@ -363,9 +431,9 @@ class ResultsPlotsTestCase(unittest.TestCase):
         self.dummy_tagger_1.f_b = 0.05
         self.dummy_tagger_1.working_point = 0.5
         rng = np.random.default_rng(seed=16)
-        self.dummy_tagger_1.perf_var = rng.exponential(
-            100, size=len(self.dummy_tagger_1.scores)
-        )
+        self.dummy_tagger_1.perf_vars = {
+            "pt": rng.exponential(100, size=len(self.dummy_tagger_1.scores))
+        }
         with tempfile.TemporaryDirectory() as tmp_file:
             results = Results(signal="cjets", sample="test", output_dir=tmp_file)
             results.add(self.dummy_tagger_1)

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -90,7 +90,6 @@ class ResultsTestCase(unittest.TestCase):
         self.assertEqual(list(results.taggers.values()), taggers)
 
     def test_add_taggers_with_cuts(self):
-        np.random.default_rng(seed=16)
         fname = get_mock_file()[0]
         cuts = [("eta", ">", 0)]
         tagger_cuts = [("pt", ">", 20)]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Add support for having multiple `VarVsEff` plots for different variables (e.g., `pt, eta`)

Relates to the following issues

* #227 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
