### PR TITLE
Allow yuma base path to work with tagger sample dir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Allow yuma base path to work with tagger sample dir [!246](https://github.com/umami-hep/puma/pull/246)
 - Fix marker resizing in VarVsVar [!243](https://github.com/umami-hep/puma/pull/243)
 
 ### [v0.3.3] (2024/02/26)

--- a/puma/hlplots/configs.py
+++ b/puma/hlplots/configs.py
@@ -80,6 +80,8 @@ class PlotConfig:
                 raise ValueError(f"No sample path defined for tagger {key}")
             if sample_path and not t.get("sample_path", None):
                 t["sample_path"] = sample_path
+            if self.base_path and t.get("sample_path", None):
+                t["sample_path"] = self.base_path / t["sample_path"]
             # Allows automatic selection of tagger name in eval files
             t["name"] = get_tagger_name(
                 t.get("name", None), t["sample_path"], key, results.flavours


### PR DESCRIPTION
## Summary

Relates to the following issues

* #244 
 
## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
