### PR TITLE
Fix taggers selection configuration for yuma

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Fix taggers selection configuration for yuma [!247](https://github.com/umami-hep/puma/pull/247)
 - Allow yuma base path to work with tagger sample dir [!246](https://github.com/umami-hep/puma/pull/246)
 - Fix marker resizing in VarVsVar [!243](https://github.com/umami-hep/puma/pull/243)
 

--- a/puma/hlplots/configs.py
+++ b/puma/hlplots/configs.py
@@ -37,7 +37,7 @@ class PlotConfig:
             date_time_file = datetime.now().strftime("%Y%m%d_%H%M%S")
             plot_dir_name += "_" + date_time_file
         self.plot_dir_final = Path(self.plot_dir) / plot_dir_name
-        # print(self.taggers_config)
+
         for k, kwargs in self.taggers_config.items():
             kwargs["yaml_name"] = k
 

--- a/puma/hlplots/configs.py
+++ b/puma/hlplots/configs.py
@@ -37,7 +37,7 @@ class PlotConfig:
             date_time_file = datetime.now().strftime("%Y%m%d_%H%M%S")
             plot_dir_name += "_" + date_time_file
         self.plot_dir_final = Path(self.plot_dir) / plot_dir_name
-
+        # print(self.taggers_config)
         for k, kwargs in self.taggers_config.items():
             kwargs["yaml_name"] = k
 
@@ -90,7 +90,8 @@ class PlotConfig:
             if "colour" not in t:
                 t["colour"] = good_colours[col_idx]
                 col_idx += 1
-            results.add(Tagger(**t))
+            if key in self.taggers:
+                results.add(Tagger(**t))
 
         results.load()
         self.results = results


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fix code to only plot specified tagger in plt_cfg.yaml when using yuma

Relates to the following issues

* #223 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
