### PR TITLE
Plot all taggers if no option specified

### DIFF
--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -64,6 +64,11 @@ class YumaConfig:
 
         for k, kwargs in self.taggers_config.items():
             kwargs["yaml_name"] = k
+        if not self.taggers:
+            logger.info("No taggers specified in config, using all")
+            self.taggers = list(self.taggers_config.keys())
+            
+
 
     @classmethod
     def load_config(cls, path: Path, **kwargs) -> YumaConfig:

--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -67,8 +67,6 @@ class YumaConfig:
         if not self.taggers:
             logger.info("No taggers specified in config, using all")
             self.taggers = list(self.taggers_config.keys())
-            
-
 
     @classmethod
     def load_config(cls, path: Path, **kwargs) -> YumaConfig:


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* By default, assume the user wants to plot all taggers in the tagger config.
* However, if they do define a 'taggers' option in the plot config, then we only plot the desired plots.

Relates to the following issues

*
*

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
