### PR TITLE
fixing crash in example - df format

### DIFF
--- a/docs/source/examples/index.md
+++ b/docs/source/examples/index.md
@@ -41,6 +41,11 @@ with h5py.File(ttbar_file, "r") as f:
     n_test = len(df)
 ```
 
+To run the next steps you need to modify the format of the dataframe:
+```
+df = df.to_records()
+```
+
 In the example below you can find an example on how you can calculate the tagger
 discriminant using the raw output (i.e. `p_u`, `p_c` and `p_b`) of the tagger,
 and a function from [atlas-ftag-tools](https://github.com/umami-hep/atlas-ftag-tools/).


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* changing the dataframe format to avoid crash


Relates to the following issues

* Example in "Some basics before plotting" crashes out of the box


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
