### PR TITLE
Minor bugfix in HF vertex merging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Fixed minor bug in HF vertex merging [!255](https://github.com/umami-hep/puma/pull/255)
 - Fixed removal of reconstructed PVs and modified which vertexing plots are produced given a jet flavour [!253](https://github.com/umami-hep/puma/pull/253)
 - Updated AuxResults class to more closely match Yuma implementation of Results class [!252](https://github.com/umami-hep/puma/pull/252)
 - Moving plotting tutorials from main FTAG page here [!249](https://github.com/umami-hep/puma/pull/249)

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -345,9 +345,7 @@ class AuxResults:
             plot_vtx_purity.savefig(self.get_filename(f"{flav}_vtx_purity_vs_{perf_var}", suffix))
 
             plot_vtx_trk_eff.draw()
-            plot_vtx_trk_eff.savefig(
-                self.get_filename(f"{flav}_vtx_trk_eff_vs_{perf_var}", suffix)
-            )
+            plot_vtx_trk_eff.savefig(self.get_filename(f"{flav}_vtx_trk_eff_vs_{perf_var}", suffix))
 
             plot_vtx_trk_purity.draw()
             plot_vtx_trk_purity.savefig(

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -258,8 +258,6 @@ class AuxResults:
         for flavour in vtx_flavours:
             if isinstance(flavour, str):
                 flav = Flavours[flavour]
-            prefix = f"{flav}_"
-            atlas_second_tag += f", {flav.label}"
 
             plot_vtx_eff = VarVsVtxPlot(
                 mode="efficiency",
@@ -267,7 +265,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag,
+                atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
             plot_vtx_purity = VarVsVtxPlot(
@@ -276,7 +274,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag,
+                atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
             plot_vtx_trk_eff = VarVsVtxPlot(
@@ -285,7 +283,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag,
+                atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
             plot_vtx_trk_purity = VarVsVtxPlot(
@@ -294,7 +292,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=self.atlas_second_tag,
+                atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
 
@@ -341,27 +339,25 @@ class AuxResults:
                 plot_vtx_trk_purity.add(vtx_trk_perf, reference=tagger.reference)
 
             plot_vtx_eff.draw()
-            plot_vtx_eff.savefig(self.get_filename(prefix + f"vtx_eff_vs_{perf_var}", suffix))
+            plot_vtx_eff.savefig(self.get_filename(f"{flav}_vtx_eff_vs_{perf_var}", suffix))
 
             plot_vtx_purity.draw()
-            plot_vtx_purity.savefig(self.get_filename(prefix + f"vtx_purity_vs_{perf_var}", suffix))
+            plot_vtx_purity.savefig(self.get_filename(f"{flav}_vtx_purity_vs_{perf_var}", suffix))
 
             plot_vtx_trk_eff.draw()
             plot_vtx_trk_eff.savefig(
-                self.get_filename(prefix + f"vtx_trk_eff_vs_{perf_var}", suffix)
+                self.get_filename(f"{flav}_vtx_trk_eff_vs_{perf_var}", suffix)
             )
 
             plot_vtx_trk_purity.draw()
             plot_vtx_trk_purity.savefig(
-                self.get_filename(prefix + f"vtx_trk_purity_vs_{perf_var}", suffix)
+                self.get_filename(f"{flav}_vtx_trk_purity_vs_{perf_var}", suffix)
             )
 
         # make plots for flavours where vertices are not expected
         for flavour in no_vtx_flavours:
             if isinstance(flavour, str):
                 flav = Flavours[flavour]
-            prefix = f"{flav}_"
-            atlas_second_tag += f", {flav.label}"
 
             plot_vtx_fakes = VarVsVtxPlot(
                 mode="fakes",
@@ -369,7 +365,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag,
+                atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
 
@@ -391,4 +387,4 @@ class AuxResults:
                 plot_vtx_fakes.add(vtx_perf, reference=tagger.reference)
 
             plot_vtx_fakes.draw()
-            plot_vtx_fakes.savefig(self.get_filename(prefix + f"vtx_fakes_vs_{perf_var}", suffix))
+            plot_vtx_fakes.savefig(self.get_filename(f"{flav}_vtx_fakes_vs_{perf_var}", suffix))

--- a/puma/utils/vertexing.py
+++ b/puma/utils/vertexing.py
@@ -319,9 +319,7 @@ def clean_reco_vertices(reco_vertices, reco_track_origin=None, incl_vertexing=Fa
 
         # merge vertices with > 0 tracks from HF and remove others
         if incl_vertexing:
-            hf_vertex_indices = np.unique(
-                reco_vertices[np.isin(reco_track_origin, [3, 4, 5, 6])]
-            )
+            hf_vertex_indices = np.unique(reco_vertices[np.isin(reco_track_origin, [3, 4, 5, 6])])
             reco_vertices = clean_indices(
                 reco_vertices,
                 np.isin(reco_vertices, hf_vertex_indices, invert=True),

--- a/puma/utils/vertexing.py
+++ b/puma/utils/vertexing.py
@@ -319,10 +319,9 @@ def clean_reco_vertices(reco_vertices, reco_track_origin=None, incl_vertexing=Fa
 
         # merge vertices with > 0 tracks from HF and remove others
         if incl_vertexing:
-            hf_vertex_indices, hf_vertex_counts = np.unique(
-                reco_vertices[np.isin(reco_track_origin, [3, 4, 5, 6])], return_counts=True
+            hf_vertex_indices = np.unique(
+                reco_vertices[np.isin(reco_track_origin, [3, 4, 5, 6])]
             )
-            hf_vertex_indices = hf_vertex_indices[hf_vertex_counts > 1]
             reco_vertices = clean_indices(
                 reco_vertices,
                 np.isin(reco_vertices, hf_vertex_indices, invert=True),


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Removed line that eliminated SV candidates for GN2 if less than 2 (rather than 1) tracks were marked as fromHF
* Fixed a bug with plot labels not showing correctly for some aux task plots

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
