### PR TITLE
Fix setting ymin_ratio (and ymax_ratio) in PlotBase if it is zero

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Fix setting ymin_ratio (and ymax_ratio) in PlotBase if it is zero 
 - Fixed shuffling bug in aux_results and modified treatment of single-track vertices [!259](https://github.com/umami-hep/puma/pull/259)
 
 ### [v0.3.4] (2024/02/26)

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### [Latest]
-- Fix setting ymin_ratio (and ymax_ratio) in PlotBase if it is zero 
+- Fix setting ymin_ratio (and ymax_ratio) in PlotBase if it is zero [!261](https://github.com/umami-hep/puma/pull/261)
 - Fixed shuffling bug in aux_results and modified treatment of single-track vertices [!259](https://github.com/umami-hep/puma/pull/259)
 
 ### [v0.3.4] (2024/02/26)

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -431,8 +431,8 @@ class PlotBase(PlotObject):
         for i, ratio_axis in enumerate(self.ratio_axes):
             if self.ymin_ratio[i] or self.ymax_ratio[i]:
                 ymin, ymax = ratio_axis.get_ylim()
-                ymin = self.ymin_ratio[i] if self.ymin_ratio[i] else ymin
-                ymax = self.ymax_ratio[i] if self.ymax_ratio[i] else ymax
+                ymin = self.ymin_ratio[i] if self.ymin_ratio[i] is not None else ymin
+                ymax = self.ymax_ratio[i] if self.ymax_ratio[i] is not None else ymax
                 ratio_axis.set_ylim(bottom=ymin, top=ymax)
 
     def set_ylabel(self, ax_mpl, label: str | None = None, align_right: bool = True, **kwargs):

--- a/puma/plot_base.py
+++ b/puma/plot_base.py
@@ -429,7 +429,7 @@ class PlotBase(PlotObject):
         )
 
         for i, ratio_axis in enumerate(self.ratio_axes):
-            if self.ymin_ratio[i] or self.ymax_ratio[i]:
+            if self.ymin_ratio[i] is not None or self.ymax_ratio[i] is not None:
                 ymin, ymax = ratio_axis.get_ylim()
                 ymin = self.ymin_ratio[i] if self.ymin_ratio[i] is not None else ymin
                 ymax = self.ymax_ratio[i] if self.ymax_ratio[i] is not None else ymax


### PR DESCRIPTION
## Summary
When setting the ymin_ratio and ymax_ratio, the originial condition 'if self.ymin_ratio[i]' evaluates to False if the values is zero. I fixed the issue by changing the condition to 'if self.ymin_ratio[i] is not None'.


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
