### PR TITLE
Fix yuma fscan

### DIFF
--- a/examples/plt_cfg.yaml
+++ b/examples/plt_cfg.yaml
@@ -43,8 +43,8 @@ plots:
 
   scan:
     - signal: bjets
-      efficiency: 0.70
       plot_kwargs:
+        efficiency: 0.70
         figsize: [8.5, 7.5]
 
   disc:

--- a/examples/plt_cfg.yaml
+++ b/examples/plt_cfg.yaml
@@ -44,6 +44,7 @@ plots:
   scan:
     - signal: bjets
       plot_kwargs:
+        backgrounds: ['cjets', 'ujets']
         efficiency: 0.70
         figsize: [8.5, 7.5]
 

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -764,7 +764,9 @@ class Results:
         if self.signal not in {Flavours.bjets, Flavours.cjets}:
             raise ValueError("Signal flavour must be bjets or cjets")
 
-        backgrounds = [Flavours[b] for b in backgrounds] if backgrounds is not None else self.backgrounds
+        backgrounds = (
+            [Flavours[b] for b in backgrounds] if backgrounds is not None else self.backgrounds
+        )
         if len(backgrounds) != 2:
             raise ValueError("Only two background flavours are supported")
 

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -764,7 +764,7 @@ class Results:
         if self.signal not in {Flavours.bjets, Flavours.cjets}:
             raise ValueError("Signal flavour must be bjets or cjets")
 
-        backgrounds = backgrounds if backgrounds is not None else self.backgrounds
+        backgrounds = [Flavours[b] for b in backgrounds] if backgrounds is not None else self.backgrounds
         if len(backgrounds) != 2:
             raise ValueError("Only two background flavours are supported")
 

--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -73,27 +73,22 @@ class YumaConfig:
             raise FileNotFoundError(f"Config at {path} does not exist")
         with open(path) as f:
             config = yaml.safe_load(f)
-        
+
         config = cls(config_path=path, **config, **kwargs)
         config._check_config()
         return config
-        
 
     def _check_config(self):
-        '''Checks the config for any issues, raises an error if any are found.'''
-        
-        allowed_keys = [
-            'signal', 'plot_kwargs', 
-            'include_taggers', 'exclude_taggers',
-            'reference'
-        ]
+        """Checks the config for any issues, raises an error if any are found."""
+        allowed_keys = ["signal", "plot_kwargs", "include_taggers", "exclude_taggers", "reference"]
         for plot_type, plots in self.plots.items():
             for p in plots:
-                for k in p.keys():
+                for k in p:
                     if k not in allowed_keys:
                         raise ValueError(
                             f"Unknown key {k} in plot config. Maybe '{k}' belongs"
-                            "under 'plot_kwargs'?")
+                            "under 'plot_kwargs'?"
+                        )
 
         return True
 

--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -73,7 +73,28 @@ class YumaConfig:
             raise FileNotFoundError(f"Config at {path} does not exist")
         with open(path) as f:
             config = yaml.safe_load(f)
-        return cls(config_path=path, **config, **kwargs)
+        
+        config = cls(config_path=path, **config, **kwargs)
+        config._check_config()
+        return config
+        
+
+    def _check_config(self):
+        '''Checks the config for any issues, raises an error if any are found.'''
+        
+        allowed_keys = [
+            'signal', 'plot_kwargs', 
+            'include_taggers', 'exclude_taggers'
+        ]
+        for plot_type, plots in self.plots.items():
+            for p in plots:
+                for k in p.keys():
+                    if k not in allowed_keys:
+                        raise ValueError(
+                            f"Unknown key {k} in plot config. Maybe '{k}' belongs"
+                            "under 'plot_kwargs'?")
+
+        return True
 
     def get_results(self):
         """

--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -84,7 +84,8 @@ class YumaConfig:
         
         allowed_keys = [
             'signal', 'plot_kwargs', 
-            'include_taggers', 'exclude_taggers'
+            'include_taggers', 'exclude_taggers',
+            'reference'
         ]
         for plot_type, plots in self.plots.items():
             for p in plots:

--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -81,7 +81,7 @@ class YumaConfig:
     def _check_config(self):
         """Checks the config for any issues, raises an error if any are found."""
         allowed_keys = ["signal", "plot_kwargs", "include_taggers", "exclude_taggers", "reference"]
-        for plot_type, plots in self.plots.items():
+        for plots in self.plots.values():
             for p in plots:
                 for k in p:
                     if k not in allowed_keys:

--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -75,10 +75,10 @@ class YumaConfig:
             config = yaml.safe_load(f)
 
         config = cls(config_path=path, **config, **kwargs)
-        config._check_config()
+        config.check_config()
         return config
 
-    def _check_config(self):
+    def check_config(self):
         """Checks the config for any issues, raises an error if any are found."""
         allowed_keys = ["signal", "plot_kwargs", "include_taggers", "exclude_taggers", "reference"]
         for plots in self.plots.values():

--- a/puma/tests/hlplots/test_yuma.py
+++ b/puma/tests/hlplots/test_yuma.py
@@ -97,6 +97,32 @@ class TestYumaPlots(unittest.TestCase):
         with self.assertRaises(SystemExit):
             main(args)
 
+    def testCheckConfig(self):
+
+        with tempfile.TemporaryDirectory() as tmp_file:
+            cpath = Path(tmp_file) / 'dummyconfig.yaml'
+            tmp_config={
+                'plot_dir' : 'test/dir',
+                'taggers_config' : {'tagger1' : {'sample_path' : 'dummy1'}},
+                'results_config' : {'sample' : 'ttbar'},
+                'plots' : {
+                    'roc' : [
+                        {
+                            'signal' : 'bjets',
+                            'include_taggers' : ['tagger1'],
+                            'efficiency' : 0.8 # Shouldn't be here
+                        }
+                    ]
+                }
+            }
+            with open(cpath, 'w') as f:
+                yaml.dump(tmp_config, f)
+            args = ["--config", cpath.as_posix(), "--signals", "bjets"]
+            with self.assertRaises(ValueError):
+                main(args)
+
+            
+
     def testAllPlots(self):
         plt_cfg = EXAMPLES / "plt_cfg.yaml"
         taggers = EXAMPLES / "taggers.yaml"

--- a/puma/tests/hlplots/test_yuma.py
+++ b/puma/tests/hlplots/test_yuma.py
@@ -98,30 +98,27 @@ class TestYumaPlots(unittest.TestCase):
             main(args)
 
     def testCheckConfig(self):
-
         with tempfile.TemporaryDirectory() as tmp_file:
-            cpath = Path(tmp_file) / 'dummyconfig.yaml'
-            tmp_config={
-                'plot_dir' : 'test/dir',
-                'taggers_config' : {'tagger1' : {'sample_path' : 'dummy1'}},
-                'results_config' : {'sample' : 'ttbar'},
-                'plots' : {
-                    'roc' : [
+            cpath = Path(tmp_file) / "dummyconfig.yaml"
+            tmp_config = {
+                "plot_dir": "test/dir",
+                "taggers_config": {"tagger1": {"sample_path": "dummy1"}},
+                "results_config": {"sample": "ttbar"},
+                "plots": {
+                    "roc": [
                         {
-                            'signal' : 'bjets',
-                            'include_taggers' : ['tagger1'],
-                            'efficiency' : 0.8 # Shouldn't be here
+                            "signal": "bjets",
+                            "include_taggers": ["tagger1"],
+                            "efficiency": 0.8,  # Shouldn't be here
                         }
                     ]
-                }
+                },
             }
-            with open(cpath, 'w') as f:
+            with open(cpath, "w") as f:
                 yaml.dump(tmp_config, f)
             args = ["--config", cpath.as_posix(), "--signals", "bjets"]
             with self.assertRaises(ValueError):
                 main(args)
-
-            
 
     def testAllPlots(self):
         plt_cfg = EXAMPLES / "plt_cfg.yaml"


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fixed the yuma example config for 'scan' type plots
* Fixed issue where 'backgrounds' weren't getting converted to 'Flavour' objects

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
