### PR TITLE
Track origin confusion matrix padding fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Removed padded tracks from consideration when generating track origin classification CM [!267](https://github.com/umami-hep/puma/pull/267)
 
 ### [v0.3.5] (2024/04/23)
 - Confusion Matrix: added per-class fake rates plus minor appearance changes [!266](https://github.com/umami-hep/puma/pull/266)

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -418,6 +418,11 @@ class AuxResults:
             target = tagger.aux_labels["track_origin"].reshape(-1)
             predictions = tagger.aux_scores["track_origin"].reshape(-1)
 
+            padding_removal = (target >= 0)
+
+            target = target[padding_removal]
+            predictions = predictions[padding_removal]
+
             # Computing the confusion matrix
             cm, eff, fake = confusion_matrix(target, predictions, normalize=normalize)
 

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -418,7 +418,7 @@ class AuxResults:
             target = tagger.aux_labels["track_origin"].reshape(-1)
             predictions = tagger.aux_scores["track_origin"].reshape(-1)
 
-            padding_removal = (target >= 0)
+            padding_removal = target >= 0
 
             target = target[padding_removal]
             predictions = predictions[padding_removal]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fixes treatment of padded tracks when calculating CM

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
