### PR TITLE
Redefine fake rate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,11 @@
 # Changelog
 
 ### [Latest]
+- Redefined fake rate [!268](https://github.com/umami-hep/puma/pull/268)
 - Removed padded tracks from consideration when generating track origin classification CM [!267](https://github.com/umami-hep/puma/pull/267)
+- Confusion Matrix: added per-class fake rates plus minor appearance changes [!266](https://github.com/umami-hep/puma/pull/266)
 
 ### [v0.3.5] (2024/04/23)
-- Confusion Matrix: added per-class fake rates plus minor appearance changes [!266](https://github.com/umami-hep/puma/pull/266)
 - Fixed a problem in the Confusion Matrix normalization, and adopted a more clear naming convention; removed decimals from the matrix plot if the entry is an integer (useful for raw counts confusion matrix) [!262](https://github.com/umami-hep/puma/pull/262)
 - Added matrix plot API, confusion matrix function, and Track Origin confusion matrix plot [!258](https://github.com/umami-hep/puma/pull/258)
 - Fix setting ymin_ratio (and ymax_ratio) in PlotBase if it is zero [!261](https://github.com/umami-hep/puma/pull/261)

--- a/docs/examples/confusion_matrix.md
+++ b/docs/examples/confusion_matrix.md
@@ -7,6 +7,19 @@ This function evaluates the (multiclass[^1]) Confusion Matrix (CM) associated to
 Mathematically, if the classification task has $N_c$ target classes, the CM is an $N_c \times N_c$ matrix whose entry $C_{i,j}$ is the number of predictions known to be in group $i$ and predicted to be in group $j$. 
 The matrix can then be normalized in different ways, obtaining rates of misclassifications instead of raw counts (more on that in [normalization](#normalization)).
 
+## Efficiency and Fake Rate
+
+For each class, the efficiency and fake rate of the classification are computed. Let:
+- $N_{c}$ be the number of samples belonging to class $c$;
+- $\hat{N}_c$ be the number of samples predicted to be from class $c$;
+- $\hat{N}_{\bar{c}}$ be the number of samples from class $c$ predicted to be from another class;
+
+Then, the efficiency is defined as:
+$$e \triangleq \frac{\hat{N}_c}{N_c}$$
+while the fake rate is defined as:
+$$f \triangleq \frac{\hat{N}_{\bar{c}}}{\hat{N}_c}$$
+
+The results for each class are returned as two arrays (`efficiencies` and `fake_rates`), where the entry $i$ is the value related to class $i$.
 
 ## Implementation
 

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -431,7 +431,7 @@ class AuxResults:
 
             if minimal_plot:
                 for i, c in enumerate(class_names):
-                    class_names_with_perf.append(f"{c}\nFake Rate = {fake[i]:.2f}")
+                    class_names_with_perf.append(f"{c}\nFake Rate = {fake[i]:.3f}")
                 # Plotting the confusion matrix
                 plot_cm = MatshowPlot(
                     x_ticklabels=class_names,
@@ -446,7 +446,7 @@ class AuxResults:
             else:
                 for i, c in enumerate(class_names):
                     class_names_with_perf.append(
-                        f"{c}\nEfficiency = {eff[i]:.2f}\nFake Rate = {fake[i]:.2f}"
+                        f"{c}\nEfficiency = {eff[i]:.3f}\nFake Rate = {fake[i]:.3f}"
                     )
                 # Plotting the confusion matrix
                 plot_cm = MatshowPlot(

--- a/puma/tests/utils/test_confusion_matrix.py
+++ b/puma/tests/utils/test_confusion_matrix.py
@@ -46,7 +46,7 @@ class ConfusionMatrixTestCase(unittest.TestCase):
         cm, eff, fake = confusion_matrix(targets, predictions, normalize=None)
         expected_cm = np.array([[2.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 2.0]])
         expected_eff = np.array([1.0, 1.0, 0.66666667])
-        expected_fake = np.array([0., 0., 0.5])
+        expected_fake = np.array([0.0, 0.0, 0.5])
         np.testing.assert_array_almost_equal(expected_cm, cm)
         np.testing.assert_array_almost_equal(expected_eff, eff)
         np.testing.assert_array_almost_equal(expected_fake, fake)

--- a/puma/tests/utils/test_confusion_matrix.py
+++ b/puma/tests/utils/test_confusion_matrix.py
@@ -46,7 +46,7 @@ class ConfusionMatrixTestCase(unittest.TestCase):
         cm, eff, fake = confusion_matrix(targets, predictions, normalize=None)
         expected_cm = np.array([[2.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 2.0]])
         expected_eff = np.array([1.0, 1.0, 0.66666667])
-        expected_fake = np.array([0.0, 0.0, 0.33333333])
+        expected_fake = np.array([0., 0., 0.5])
         np.testing.assert_array_almost_equal(expected_cm, cm)
         np.testing.assert_array_almost_equal(expected_eff, eff)
         np.testing.assert_array_almost_equal(expected_fake, fake)

--- a/puma/utils/confusion_matrix.py
+++ b/puma/utils/confusion_matrix.py
@@ -85,7 +85,7 @@ def confusion_matrix(
         Npred_this_class = row[i]
         Npred_other_class = N_this_class - Npred_this_class
         efficiencies.append(Npred_this_class / N_this_class)
-        fake_rates.append(Npred_other_class / N_this_class)
+        fake_rates.append(Npred_other_class / Npred_this_class)
 
     efficiencies = np.array(efficiencies)
     fake_rates = np.array(fake_rates)


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Changed the definition of fake rate, from
```math
f \triangleq \frac{\hat{N}_{\bar{c}}}{N_c}
```
to
```math
f \triangleq \frac{\hat{N}_{\bar{c}}}{\hat{N}_c}
```

* Wrote the efficiency and fake rate definitions in the CM docs
* Uniformed the float precision of the efficiencies and fake rates to the one of the CM entries

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
