### PR TITLE
Fixed fake rate normalization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Fixed fake rate normalization [!269](https://github.com/umami-hep/puma/pull/269)
 - Redefined fake rate [!268](https://github.com/umami-hep/puma/pull/268)
 - Removed padded tracks from consideration when generating track origin classification CM [!267](https://github.com/umami-hep/puma/pull/267)
 - Confusion Matrix: added per-class fake rates plus minor appearance changes [!266](https://github.com/umami-hep/puma/pull/266)

--- a/docs/examples/confusion_matrix.md
+++ b/docs/examples/confusion_matrix.md
@@ -11,11 +11,12 @@ The matrix can then be normalized in different ways, obtaining rates of misclass
 
 For each class, the efficiency and fake rate of the classification are computed. Let:
 - $N_{c}$ be the number of samples belonging to class $c$;
-- $\hat{N}_c$ be the number of samples predicted to be from class $c$;
+- $\hat{N}_{cc}$ be the number of samples from class $c$ correctly predicted to be from class $c$;
+- $\hat{N}_{c}$ be the number of samples predicted to be from class $c$, independently of their true origin;
 - $\hat{N}_{\bar{c}}$ be the number of samples from class $c$ predicted to be from another class;
 
 Then, the efficiency is defined as:
-$$e \triangleq \frac{\hat{N}_c}{N_c}$$
+$$e \triangleq \frac{\hat{N}_c}{N_{cc}}$$
 while the fake rate is defined as:
 $$f \triangleq \frac{\hat{N}_{\bar{c}}}{\hat{N}_c}$$
 

--- a/docs/examples/confusion_matrix.md
+++ b/docs/examples/confusion_matrix.md
@@ -16,7 +16,7 @@ For each class, the efficiency and fake rate of the classification are computed.
 - $\hat{N}_{\bar{c}}$ be the number of samples from class $c$ predicted to be from another class;
 
 Then, the efficiency is defined as:
-$$e \triangleq \frac{\hat{N}_c}{N_{cc}}$$
+$$e \triangleq \frac{\hat{N}_{cc}}{N_{c}}$$
 while the fake rate is defined as:
 $$f \triangleq \frac{\hat{N}_{\bar{c}}}{\hat{N}_c}$$
 

--- a/puma/utils/confusion_matrix.py
+++ b/puma/utils/confusion_matrix.py
@@ -85,7 +85,8 @@ def confusion_matrix(
         Npred_this_class = row[i]
         Npred_other_class = N_this_class - Npred_this_class
         efficiencies.append(Npred_this_class / N_this_class)
-        fake_rates.append(Npred_other_class / Npred_this_class)
+        Npred_this_class_with_errors = np.sum(cm[:, i])
+        fake_rates.append(Npred_other_class / Npred_this_class_with_errors)
 
     efficiencies = np.array(efficiencies)
     fake_rates = np.array(fake_rates)


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* The fake count is now normalized over all samples predicted to be from class $c$, independently of their true origin (before it was normalized over samples from class $c$ correctly predicted, which didn't guarantee a normalization to 1).


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
