### PR TITLE
Update names of aux variables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Updated variable names for aux task outputs to be consistent with Salt [!270](https://github.com/umami-hep/puma/pull/270)
 - Redefined fake rate [!268](https://github.com/umami-hep/puma/pull/268)
 - Removed padded tracks from consideration when generating track origin classification CM [!267](https://github.com/umami-hep/puma/pull/267)
 - Confusion Matrix: added per-class fake rates plus minor appearance changes [!266](https://github.com/umami-hep/puma/pull/266)

--- a/puma/hlplots/tagger.py
+++ b/puma/hlplots/tagger.py
@@ -118,9 +118,9 @@ class Tagger:
                 if self.name in {"SV1", "JF"}:
                     aux_outputs[aux_type] = f"{self.name}VertexIndex"
                 else:
-                    aux_outputs[aux_type] = f"{self.name}_VertexIndex"
+                    aux_outputs[aux_type] = f"auxtask_{self.name}_VertexIndex"
             elif aux_type == "track_origin":
-                aux_outputs[aux_type] = f"{self.name}_TrackOrigin"
+                aux_outputs[aux_type] = f"auxtask_{self.name}_TrackOrigin"
             else:
                 raise ValueError(f"{aux_type} is not a recognized aux task.")
 

--- a/puma/hlplots/tagger.py
+++ b/puma/hlplots/tagger.py
@@ -118,9 +118,9 @@ class Tagger:
                 if self.name in {"SV1", "JF"}:
                     aux_outputs[aux_type] = f"{self.name}VertexIndex"
                 else:
-                    aux_outputs[aux_type] = f"auxtask_{self.name}_VertexIndex"
+                    aux_outputs[aux_type] = f"{self.name}_aux_VertexIndex"
             elif aux_type == "track_origin":
-                aux_outputs[aux_type] = f"auxtask_{self.name}_TrackOrigin"
+                aux_outputs[aux_type] = f"{self.name}_aux_TrackOrigin"
             else:
                 raise ValueError(f"{aux_type} is not a recognized aux task.")
 

--- a/puma/tests/hlplots/test_aux_results.py
+++ b/puma/tests/hlplots/test_aux_results.py
@@ -150,8 +150,8 @@ class AuxResultsPlotsTestCase(unittest.TestCase):
             dtype=[("HadronConeExclTruthLabelID", "i4")],
         )
         dummy_tagger.aux_scores = {
-            "vertexing": f["tracks"]["GN2_VertexIndex"],
-            "track_origin": f["tracks"]["GN2_TrackOrigin"],
+            "vertexing": f["tracks"]["auxtask_GN2_VertexIndex"],
+            "track_origin": f["tracks"]["auxtask_GN2_TrackOrigin"],
         }
         dummy_tagger.aux_labels = {
             "vertexing": f["tracks"]["ftagTruthVertexIndex"],

--- a/puma/tests/hlplots/test_aux_results.py
+++ b/puma/tests/hlplots/test_aux_results.py
@@ -150,8 +150,8 @@ class AuxResultsPlotsTestCase(unittest.TestCase):
             dtype=[("HadronConeExclTruthLabelID", "i4")],
         )
         dummy_tagger.aux_scores = {
-            "vertexing": f["tracks"]["auxtask_GN2_VertexIndex"],
-            "track_origin": f["tracks"]["auxtask_GN2_TrackOrigin"],
+            "vertexing": f["tracks"]["GN2_aux_VertexIndex"],
+            "track_origin": f["tracks"]["GN2_aux_TrackOrigin"],
         }
         dummy_tagger.aux_labels = {
             "vertexing": f["tracks"]["ftagTruthVertexIndex"],

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -188,14 +188,14 @@ class TaggerAuxTaskTestCase(unittest.TestCase):
         default_tagger = Tagger("dummy", aux_tasks=["vertexing"])
         SV1_tagger = Tagger("SV1", aux_tasks=["vertexing"])
         JF_tagger = Tagger("JF", aux_tasks=["vertexing"])
-        self.assertEqual(default_tagger.aux_variables["vertexing"], "auxtask_dummy_VertexIndex")
+        self.assertEqual(default_tagger.aux_variables["vertexing"], "dummy_aux_VertexIndex")
         self.assertEqual(SV1_tagger.aux_variables["vertexing"], "SV1VertexIndex")
         self.assertEqual(JF_tagger.aux_variables["vertexing"], "JFVertexIndex")
 
     def test_aux_variables_track_origin(self):
         """Test track_origin aux task variable retrieval."""
         tagger = Tagger("dummy", aux_tasks=["track_origin"])
-        self.assertEqual(tagger.aux_variables["track_origin"], "auxtask_dummy_TrackOrigin")
+        self.assertEqual(tagger.aux_variables["track_origin"], "dummy_aux_TrackOrigin")
 
     def test_aux_variables_undefined(self):
         """Test undefined aux task variable retrieval."""

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -188,14 +188,14 @@ class TaggerAuxTaskTestCase(unittest.TestCase):
         default_tagger = Tagger("dummy", aux_tasks=["vertexing"])
         SV1_tagger = Tagger("SV1", aux_tasks=["vertexing"])
         JF_tagger = Tagger("JF", aux_tasks=["vertexing"])
-        self.assertEqual(default_tagger.aux_variables["vertexing"], "dummy_VertexIndex")
+        self.assertEqual(default_tagger.aux_variables["vertexing"], "auxtask_dummy_VertexIndex")
         self.assertEqual(SV1_tagger.aux_variables["vertexing"], "SV1VertexIndex")
         self.assertEqual(JF_tagger.aux_variables["vertexing"], "JFVertexIndex")
 
     def test_aux_variables_track_origin(self):
         """Test track_origin aux task variable retrieval."""
         tagger = Tagger("dummy", aux_tasks=["track_origin"])
-        self.assertEqual(tagger.aux_variables["track_origin"], "dummy_TrackOrigin")
+        self.assertEqual(tagger.aux_variables["track_origin"], "auxtask_dummy_TrackOrigin")
 
     def test_aux_variables_undefined(self):
         """Test undefined aux task variable retrieval."""

--- a/puma/utils/generate.py
+++ b/puma/utils/generate.py
@@ -173,9 +173,9 @@ def get_dummy_tagger_aux(
     trk_or_reco = np.random.choice(8, size=(len(df_gen), n_tracks)).astype(int)
     aux_dtype = np.dtype([
         ("ftagTruthVertexIndex", "i4"),
-        ("GN2_VertexIndex", "i4"),
+        ("auxtask_GN2_VertexIndex", "i4"),
         ("ftagTruthOriginLabel", "i4"),
-        ("GN2_TrackOrigin", "i4"),
+        ("auxtask_GN2_TrackOrigin", "i4"),
     ])
     aux_info = np.rec.fromarrays(
         [vtx_labels, vtx_reco, trk_or_labels, trk_or_reco], dtype=aux_dtype

--- a/puma/utils/generate.py
+++ b/puma/utils/generate.py
@@ -173,9 +173,9 @@ def get_dummy_tagger_aux(
     trk_or_reco = np.random.choice(8, size=(len(df_gen), n_tracks)).astype(int)
     aux_dtype = np.dtype([
         ("ftagTruthVertexIndex", "i4"),
-        ("auxtask_GN2_VertexIndex", "i4"),
+        ("GN2_aux_VertexIndex", "i4"),
         ("ftagTruthOriginLabel", "i4"),
-        ("auxtask_GN2_TrackOrigin", "i4"),
+        ("GN2_aux_TrackOrigin", "i4"),
     ])
     aux_info = np.rec.fromarrays(
         [vtx_labels, vtx_reco, trk_or_labels, trk_or_reco], dtype=aux_dtype


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Updated names of aux task output variables to match Salt

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
