### PR TITLE
Minor update for auxtask plots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Minor updates for aux task plots [!273](https://github.com/umami-hep/puma/pull/273)
 - Redefined fake rate [!268](https://github.com/umami-hep/puma/pull/268)
 - Removed padded tracks from consideration when generating track origin classification CM [!267](https://github.com/umami-hep/puma/pull/267)
 - Confusion Matrix: added per-class fake rates plus minor appearance changes [!266](https://github.com/umami-hep/puma/pull/266)

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -262,36 +262,40 @@ class AuxResults:
             if isinstance(flavour, str):
                 flav = Flavours[flavour]
 
+            # $n_{vtx}^{match}/n_{vtx}^{true}$
             plot_vtx_eff = VarVsVtxPlot(
                 mode="efficiency",
-                ylabel=r"$n_{vtx}^{match}/n_{vtx}^{true}$",
+                ylabel="Efficiency",
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
                 atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
+            # $n_{vtx}^{match}/n_{vtx}^{reco}$
             plot_vtx_purity = VarVsVtxPlot(
                 mode="purity",
-                ylabel=r"$n_{vtx}^{match}/n_{vtx}^{reco}$",
+                ylabel="Purity",
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
                 atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
+            # $n_{trk}^{match}/n_{trk}^{true}$
             plot_vtx_trk_eff = VarVsVtxPlot(
                 mode="efficiency",
-                ylabel=r"$n_{trk}^{match}/n_{trk}^{true}$",
+                ylabel="Track Assignment Efficiency",
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
                 atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
+            # $n_{trk}^{match}/n_{trk}^{reco}$
             plot_vtx_trk_purity = VarVsVtxPlot(
                 mode="purity",
-                ylabel=r"$n_{trk}^{match}/n_{trk}^{reco}$",
+                ylabel="Track Assignment Purity",
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
@@ -362,7 +366,7 @@ class AuxResults:
 
             plot_vtx_fakes = VarVsVtxPlot(
                 mode="fakes",
-                ylabel=r"$n_{vtx}^{reco}$",
+                ylabel="Vertex Rate",
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -461,6 +461,7 @@ class AuxResults:
                     ylabel="Target Classes",
                     atlas_second_tag=self.atlas_second_tag,
                     atlas_tag_outside=True,
+                    show_cbar=False,
                     **kwargs,
                 )
             plot_cm.draw(cm)

--- a/puma/matshow.py
+++ b/puma/matshow.py
@@ -21,7 +21,7 @@ class MatshowPlot(PlotBase):
         show_percentage: bool = False,
         text_color_threshold: float = 0.408,
         colormap: plt.cm = plt.cm.Oranges,
-        show_cbar: bool = False,
+        show_cbar: bool = True,
         cbar_label: str | None = None,
         **kwargs,
     ) -> None:

--- a/puma/matshow.py
+++ b/puma/matshow.py
@@ -21,7 +21,7 @@ class MatshowPlot(PlotBase):
         show_percentage: bool = False,
         text_color_threshold: float = 0.408,
         colormap: plt.cm = plt.cm.Oranges,
-        show_cbar: bool = True,
+        show_cbar: bool = False,
         cbar_label: str | None = None,
         **kwargs,
     ) -> None:


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* No colour bar by default for confusion matrices
* Better ylabel axis names for vertexing plots

cc @jmw464 @LucioDerin 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
