### PR TITLE
Precision and Recall scores

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Added functions for precision and recall scores [!275](https://github.com/umami-hep/puma/pull/275)
 - Minor updates for aux task plots [!273](https://github.com/umami-hep/puma/pull/273)
 - Added better support in yuma, allowing for tau rejection, tau tagging, and Xbb plots [!272](https://github.com/umami-hep/puma/pull/272)
 - Redefined fake rate [!268](https://github.com/umami-hep/puma/pull/268)

--- a/docs/examples/confusion_matrix.md
+++ b/docs/examples/confusion_matrix.md
@@ -1,25 +1,11 @@
 # Confusion Matrix
 
-This function evaluates the (multiclass[^1]) Confusion Matrix (CM) associated to a classifier output predictions. The CM is a metric that measures the misclassification rates between all the classes in the classification task. It also evaluates the per-class efficiencies and fake rates. It returns three `np.ndarray`s: the CM, the efficiencies, and the fake rates.
+This function evaluates the (multiclass[^1]) Confusion Matrix (CM) associated to a classifier output predictions. The CM is a metric that measures the misclassification rates between all the classes in the classification task.
 
 ## Mathematical definition
 
 Mathematically, if the classification task has $N_c$ target classes, the CM is an $N_c \times N_c$ matrix whose entry $C_{i,j}$ is the number of predictions known to be in group $i$ and predicted to be in group $j$. 
 The matrix can then be normalized in different ways, obtaining rates of misclassifications instead of raw counts (more on that in [normalization](#normalization)).
-
-## Efficiency and Fake Rate
-
-For each class, the efficiency and fake rate of the classification are computed. Let:
-- $N_{c}$ be the number of samples belonging to class $c$;
-- $\hat{N}_c$ be the number of samples predicted to be from class $c$;
-- $\hat{N}_{\bar{c}}$ be the number of samples from class $c$ predicted to be from another class;
-
-Then, the efficiency is defined as:
-$$e \triangleq \frac{\hat{N}_c}{N_c}$$
-while the fake rate is defined as:
-$$f \triangleq \frac{\hat{N}_{\bar{c}}}{\hat{N}_c}$$
-
-The results for each class are returned as two arrays (`efficiencies` and `fake_rates`), where the entry $i$ is the value related to class $i$.
 
 ## Implementation
 
@@ -27,7 +13,7 @@ The function `confusion_matrix` in `puma.utils.confusion_matrix` computes the CM
 ```python
 targets = np.array([2, 0, 2, 2, 0, 1])
 predictions = np.array([0, 0, 2, 2, 0, 2])
-cm, eff, fake = confusion_matrix(targets, predictions)
+confusion_matrix(targets, predictions)
 ```
 
 Eventually, samples can be weighted by their relative importance by providing an array of weights $w_i \in [0,1]$:
@@ -35,7 +21,7 @@ Eventually, samples can be weighted by their relative importance by providing an
 targets = np.array([2, 0, 2, 2, 0, 1])
 predictions = np.array([0, 0, 2, 2, 0, 2])
 weights = np.array([1, 0.5, 0.5, 1, 0.2, 1])
-cm, eff, fake = confusion_matrix(targets, predictions, sample_weights=weights)
+confusion_matrix(targets, predictions, sample_weights=weights)
 ```
 
 

--- a/docs/examples/confusion_matrix.md
+++ b/docs/examples/confusion_matrix.md
@@ -27,11 +27,7 @@ confusion_matrix(targets, predictions, sample_weights=weights)
 
 ### Normalization
 
-There are four possible normalization choices, which can be selected through the `normalize` argument of the function:
-- `None`: Give raw counts;
-- `"rownorm"`: Normalize across the prediction class, i.e. such that the rows add to one (default);
-- `"colnorm"`: Normalize across the target class, i.e. such that the columns add to one;
-- `"all" `: Normalize across all examples, i.e. such that all matrix entries add to one. Defaults to "all".
+There are four possible normalization choices, which can be selected through the `normalize` argument of the function: `None` to use raw counts; `"rownorm"` to normalize across the prediction class, i.e. such that the rows add to one (default); `"colnorm"` to normalize across the target class, i.e. such that the columns add to one; `"all" ` to normalize across all examples, i.e. such that all matrix entries add to one. Defaults to `"rownorm"`.
 
 ## Example
 

--- a/docs/examples/precision_recall.md
+++ b/docs/examples/precision_recall.md
@@ -1,0 +1,26 @@
+# Precision and Recall
+
+The functions in `puma.utils.precision_score` and in `puma.utils.recall_score` compute the per-class precision and recall classification metrics, for a multiclass classification task with $N_c$ classes. The metrics are computed by comparing the classifier's predicted labels array with the target labels array. The functions return an array where the entry $i$ is the score related to class $i$. The scores are defined as follows.
+
+## Precision
+
+Fixed a class $i$ between the $N_c$ possible classes, the precision score (also called purity) for that class measures the ability of the classifier to not label as class $i$ a sample belonging to another class. It is defined as:
+
+$$p = \frac{tp}{tp+fp}$$
+
+where $tp$ is the true positives count and $fp$ is the false positives count in the test set.
+
+## Recall
+
+Fixed a class $i$ between the $N_c$ possible classes, the recall score for that class measures the ability of the classifier to detect every sample belonging to class $i$ in the set. It is defined as:
+
+$$r = \frac{tp}{tp+fn}$$
+
+where $tp$ is the true positives count and $fn$ is the false negatives count in the test set.
+
+## Example
+
+
+```py
+--8<-- "examples/precision_recall_examples.py"
+```

--- a/docs/hlapi/high_level_aux_api.md
+++ b/docs/hlapi/high_level_aux_api.md
@@ -59,6 +59,7 @@ efficiency > 0.65 and purity > 0.5
 ## Track Origin Performances
 
 The Track Origin auxiliary task is a multiclass classification task, in which each track is associated with its most probable belonging origin, chosen between:
+
 - Pileup;
 - Fake;
 - Primary;

--- a/examples/confusion_matrix_examples.py
+++ b/examples/confusion_matrix_examples.py
@@ -11,10 +11,12 @@ N = 100
 Nclass = 3
 
 # Dummy target labels
-targets = np.random.randint(0, Nclass + 1, size=N)
+targets = np.random.randint(0, Nclass, size=N)
+# Making sure that there is at least one sample for each class
+targets = np.append(targets, np.array(list(range(Nclass))))
 
 # Dummy predicted labels
-predictions = np.random.randint(0, Nclass + 1, size=N)
+predictions = np.random.randint(0, Nclass, size=(N + Nclass))
 
 
 # Confusion matrix examples:
@@ -39,7 +41,7 @@ print(" ")
 
 # Weighted Confusion Matrix
 # Dummy sample weights
-sample_weights = np.random.rand(N)
+sample_weights = np.random.rand(N + Nclass)
 
 weighted_cm = confusion_matrix(targets, predictions, sample_weights=sample_weights)
 print("Weighted CM:")

--- a/examples/confusion_matrix_examples.py
+++ b/examples/confusion_matrix_examples.py
@@ -20,31 +20,27 @@ predictions = np.random.randint(0, Nclass + 1, size=N)
 # Confusion matrix examples:
 
 # Unweighted confusion matrix, normalized on all entries
-unweighted_cm, _, _ = confusion_matrix(targets, predictions, normalize="all")
+unweighted_cm = confusion_matrix(targets, predictions, normalize="all")
 print("Unweighted, normalized on all entries, CM:")
 print(unweighted_cm)
 print(" ")
 
 # Unweighted confusion matrix, normalized on true labels
-unweighted_cm, _, _ = confusion_matrix(targets, predictions, normalize="rownorm")
+unweighted_cm = confusion_matrix(targets, predictions, normalize="rownorm")
 print("Unweighted, normalized true labels (rownorm), CM:")
 print(unweighted_cm)
 print(" ")
 
 # Unweighted confusion matrix, with raw counts (non-normalized)
-unweighted_cm, eff, fake = confusion_matrix(targets, predictions, normalize=None)
+unweighted_cm = confusion_matrix(targets, predictions, normalize=None)
 print("Unweighted, non-normalized, CM:")
 print(unweighted_cm)
-print("Efficiencies:")
-print(eff)
-print("Fake rate:")
-print(fake)
 print(" ")
 
 # Weighted Confusion Matrix
 # Dummy sample weights
 sample_weights = np.random.rand(N)
 
-weighted_cm, _, _ = confusion_matrix(targets, predictions, sample_weights=sample_weights)
+weighted_cm = confusion_matrix(targets, predictions, sample_weights=sample_weights)
 print("Weighted CM:")
 print(weighted_cm)

--- a/examples/precision_recall_examples.py
+++ b/examples/precision_recall_examples.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import numpy as np
+
+from puma.utils.precision_score import precision_score_per_class
+from puma.utils.recall_score import recall_score_per_class
+
+# Sample size
+N = 100
+
+# Number of target classes
+Nclass = 3
+
+# Dummy target labels
+targets = np.random.randint(0, Nclass, size=N)
+# Making sure that there is at least one sample for each class
+targets = np.append(targets, np.array(list(range(Nclass))))
+
+# Dummy predicted labels
+predictions = np.random.randint(0, Nclass, size=(N + Nclass))
+
+
+# Unweighted precision and recall
+uw_precision = precision_score_per_class(targets, predictions)
+uw_recall = recall_score_per_class(targets, predictions)
+print("Unweighted case:")
+print("Per-class precision:")
+print(uw_precision)
+print("Per-class recall:")
+print(uw_recall)
+print(" ")
+
+# Weighted precision and recall
+# Dummy sample weights
+sample_weights = np.random.rand(N + Nclass)
+
+uw_precision = precision_score_per_class(targets, predictions, sample_weights)
+uw_recall = recall_score_per_class(targets, predictions, sample_weights)
+print("Weighted case:")
+print("Per-class precision:")
+print(uw_precision)
+print("Per-class recall:")
+print(uw_recall)
+print(" ")

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -14,6 +14,8 @@ from puma.matshow import MatshowPlot
 from puma.utils import logger
 from puma.utils.aux import get_aux_labels, get_trackOrigin_classNames
 from puma.utils.confusion_matrix import confusion_matrix
+from puma.utils.precision_score import precision_score_per_class
+from puma.utils.recall_score import recall_score_per_class
 from puma.utils.vertexing import calculate_vertex_metrics
 from puma.var_vs_vtx import VarVsVtx, VarVsVtxPlot
 
@@ -429,15 +431,18 @@ class AuxResults:
 
             # Computing the confusion matrix
             cm = confusion_matrix(target, predictions, normalize=normalize)
-            precision = ...
-            recall = ...
+            precision = precision_score_per_class(target, predictions)
+            recall = recall_score_per_class(target, predictions)
 
             class_names = get_trackOrigin_classNames()
             class_names_with_perf = []
 
             if minimal_plot:
                 for i, c in enumerate(class_names):
-                    class_names_with_perf.append(f"{c}\nRecall = {recall[i]:.3f}")
+                    # class_names_with_perf.append(f"{c}\nRecall = {recall[i]:.3f}")
+                    class_names_with_perf.append(
+                        f"{c}\nPrecision = {precision[i]:.3f}\nRecall = {recall[i]:.3f}"
+                    )
                 # Plotting the confusion matrix
                 plot_cm = MatshowPlot(
                     x_ticklabels=class_names,

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -428,14 +428,16 @@ class AuxResults:
             predictions = predictions[padding_removal]
 
             # Computing the confusion matrix
-            cm, eff, fake = confusion_matrix(target, predictions, normalize=normalize)
+            cm = confusion_matrix(target, predictions, normalize=normalize)
+            precision = ...
+            recall = ...
 
             class_names = get_trackOrigin_classNames()
             class_names_with_perf = []
 
             if minimal_plot:
                 for i, c in enumerate(class_names):
-                    class_names_with_perf.append(f"{c}\nFake Rate = {fake[i]:.3f}")
+                    class_names_with_perf.append(f"{c}\nRecall = {recall[i]:.3f}")
                 # Plotting the confusion matrix
                 plot_cm = MatshowPlot(
                     x_ticklabels=class_names,
@@ -450,7 +452,7 @@ class AuxResults:
             else:
                 for i, c in enumerate(class_names):
                     class_names_with_perf.append(
-                        f"{c}\nEfficiency = {eff[i]:.3f}\nFake Rate = {fake[i]:.3f}"
+                        f"{c}\nPrecision = {precision[i]:.3f}\nRecall = {recall[i]:.3f}"
                     )
                 # Plotting the confusion matrix
                 plot_cm = MatshowPlot(

--- a/puma/tests/utils/test_confusion_matrix.py
+++ b/puma/tests/utils/test_confusion_matrix.py
@@ -14,7 +14,7 @@ class ConfusionMatrixTestCase(unittest.TestCase):
     def test_confusion_matrix_unweighted(self):
         targets = np.array([2, 0, 2, 2, 0, 1])
         predictions = np.array([0, 0, 2, 2, 0, 2])
-        cm, _, _ = confusion_matrix(targets, predictions, normalize="all")
+        cm = confusion_matrix(targets, predictions, normalize="all")
         expected_cm = np.array([
             [0.33333333, 0.0, 0.0],
             [0.0, 0.0, 0.16666667],
@@ -25,14 +25,14 @@ class ConfusionMatrixTestCase(unittest.TestCase):
     def test_confusion_matrix_unweighted_colnorm(self):
         targets = np.array([2, 0, 2, 2, 0, 1])
         predictions = np.array([0, 0, 2, 2, 0, 1])
-        cm, _, _ = confusion_matrix(targets, predictions, normalize="colnorm")
+        cm = confusion_matrix(targets, predictions, normalize="colnorm")
         expected_cm = np.array([[0.66666667, 0.0, 0.0], [0.0, 1.0, 0.0], [0.33333333, 0.0, 1.0]])
         np.testing.assert_array_almost_equal(expected_cm, cm)
 
     def test_confusion_matrix_unweighted_rownorm(self):
         targets = np.array([2, 0, 2, 2, 0, 1])
         predictions = np.array([0, 0, 2, 2, 0, 1])
-        cm, _, _ = confusion_matrix(targets, predictions, normalize="rownorm")
+        cm = confusion_matrix(targets, predictions, normalize="rownorm")
         expected_cm = np.array([
             [1.0, 0.0, 0.0],
             [0.0, 1.0, 0.0],
@@ -43,19 +43,15 @@ class ConfusionMatrixTestCase(unittest.TestCase):
     def test_confusion_matrix_unweighted_normNone(self):
         targets = np.array([2, 0, 2, 2, 0, 1])
         predictions = np.array([0, 0, 2, 2, 0, 1])
-        cm, eff, fake = confusion_matrix(targets, predictions, normalize=None)
+        cm = confusion_matrix(targets, predictions, normalize=None)
         expected_cm = np.array([[2.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 2.0]])
-        expected_eff = np.array([1.0, 1.0, 0.66666667])
-        expected_fake = np.array([0.0, 0.0, 0.5])
         np.testing.assert_array_almost_equal(expected_cm, cm)
-        np.testing.assert_array_almost_equal(expected_eff, eff)
-        np.testing.assert_array_almost_equal(expected_fake, fake)
 
     def test_confusion_matrix_weighted(self):
         targets = np.array([2, 0, 2, 2, 0, 1])
         predictions = np.array([0, 0, 2, 2, 0, 2])
         weights = np.array([1, 0.5, 0.5, 1, 0.2, 1])
-        cm, _, _ = confusion_matrix(targets, predictions, sample_weights=weights, normalize="all")
+        cm = confusion_matrix(targets, predictions, sample_weights=weights, normalize="all")
         expected_cm = np.array([
             [0.16666667, 0.0, 0.0],
             [0.0, 0.0, 0.23809524],

--- a/puma/tests/utils/test_precision.py
+++ b/puma/tests/utils/test_precision.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from puma.utils import logger, set_log_level
+from puma.utils.precision_score import precision_score_per_class
+
+set_log_level(logger, "DEBUG")
+
+
+class ConfusionMatrixTestCase(unittest.TestCase):
+    def test_precision_unweighted(self):
+        targets = np.array([2, 0, 2, 2, 0, 1])
+        predictions = np.array([0, 0, 2, 2, 0, 2])
+        precision = precision_score_per_class(targets, predictions)
+        expected_precision = np.array([0.66666667, 0.0, 0.66666667])
+        np.testing.assert_array_almost_equal(expected_precision, precision)
+
+    def test_precision_weighted(self):
+        targets = np.array([2, 0, 2, 2, 0, 1])
+        predictions = np.array([0, 0, 2, 2, 0, 2])
+        weights = np.array([1, 0.5, 0.5, 1, 0.2, 1])
+        precision = precision_score_per_class(targets, predictions, weights)
+        expected_precision = np.array([0.41176471, 0.0, 0.6])
+        np.testing.assert_array_almost_equal(expected_precision, precision)

--- a/puma/tests/utils/test_recall.py
+++ b/puma/tests/utils/test_recall.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from puma.utils import logger, set_log_level
+from puma.utils.recall_score import recall_score_per_class
+
+set_log_level(logger, "DEBUG")
+
+
+class ConfusionMatrixTestCase(unittest.TestCase):
+    def test_precision_unweighted(self):
+        targets = np.array([2, 0, 2, 2, 0, 1])
+        predictions = np.array([0, 0, 2, 2, 0, 2])
+        recall = recall_score_per_class(targets, predictions)
+        expected_recall = np.array([1.0, 0.0, 0.66666667])
+        np.testing.assert_array_almost_equal(expected_recall, recall)
+
+    def test_precision_weighted(self):
+        targets = np.array([2, 0, 2, 2, 0, 1])
+        predictions = np.array([0, 0, 2, 2, 0, 2])
+        weights = np.array([1, 0.5, 0.5, 1, 0.2, 1])
+        recall = recall_score_per_class(targets, predictions, weights)
+        expected_recall = np.array([1.0, 0.0, 0.6])
+        np.testing.assert_array_almost_equal(expected_recall, recall)

--- a/puma/utils/confusion_matrix.py
+++ b/puma/utils/confusion_matrix.py
@@ -13,9 +13,9 @@ def confusion_matrix(
     """
     Parameters
     ----------
-    targets : np.ndarray
+    targets : 1d np.ndarray
         target labels
-    predictions : np.ndarray
+    predictions : 1d np.ndarray
         predicted labels (output of the classifier)
     sample_weights : np.ndarray, optional
         Weight of each sample; if None, each sample weights the same. Defaults to None.

--- a/puma/utils/confusion_matrix.py
+++ b/puma/utils/confusion_matrix.py
@@ -29,17 +29,14 @@ def confusion_matrix(
 
     Returns
     -------
-    np.ndarray : the confusion matrix,
-    np.dnarray : the per-class efficiencies,
-    np.ndarray : the per-class fake rates.
+    np.ndarray : the confusion matrix.
 
     Example
     --------
     >>> targets = np.array([2, 0, 2, 2, 0, 1])
     >>> predictions = np.array([0, 0, 2, 2, 0, 2])
     >>> weights = np.array([1, 0.5, 0.5, 1, 0.2, 1])
-    >>> cm, eff, fake = confusion_matrix(targets, predictions, sample_weights=weights)
-    >>> print(cm)
+    >>> confusion_matrix(targets, predictions, sample_weights=weights)
     np.array([[1.  0.  0. ]
         [0.  0.  1. ]
         [0.4 0.  0.6]])
@@ -77,19 +74,6 @@ def confusion_matrix(
         dtype="float",
     ).toarray()
 
-    # Calculate efficiency and fake rate
-    efficiencies = []
-    fake_rates = []
-    for i, row in enumerate(cm):
-        N_this_class = np.sum(row)
-        Npred_this_class = row[i]
-        Npred_other_class = N_this_class - Npred_this_class
-        efficiencies.append(Npred_this_class / N_this_class)
-        fake_rates.append(Npred_other_class / Npred_this_class)
-
-    efficiencies = np.array(efficiencies)
-    fake_rates = np.array(fake_rates)
-
     # Eventually normalize the Confusion Matrix
     with np.errstate(all="warn"):
         if normalize == "all":
@@ -100,4 +84,4 @@ def confusion_matrix(
             cm /= cm.sum(axis=0, keepdims=True)
 
     # Returning the CM with nan converted to zero
-    return np.nan_to_num(cm), efficiencies, fake_rates
+    return np.nan_to_num(cm)

--- a/puma/utils/precision_score.py
+++ b/puma/utils/precision_score.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import numpy as np
+
+from puma.utils.confusion_matrix import confusion_matrix
+
+
+def precision_score_per_class(
+    targets: np.ndarray,
+    predictions: np.ndarray,
+    sample_weights: np.ndarray | None = None,
+) -> np.ndarray:
+    """
+    The precision score is defined, for each class, as ``tp / (tp + fp)``,
+    where ``tp`` is the number of true positives and ``fp`` is the number of false positives.
+
+    Parameters
+    ----------
+    targets : 1d np.ndarray
+        target labels
+    predictions : 1d np.ndarray
+        predicted labels (output of the classifier)
+    sample_weights : np.ndarray, optional
+        Weight of each sample; if None, each sample weights the same. Defaults to None.
+
+    Returns
+    -------
+    np.ndarray : the per-class precision score.
+
+    Example
+    --------
+    >>> targets = np.array([2, 0, 2, 2, 0, 1])
+    >>> predictions = np.array([0, 0, 2, 2, 0, 2])
+    >>> weights = np.array([1, 0.5, 0.5, 1, 0.2, 1])
+    >>> precision_score_per_class(targets, predictions, sample_weights=weights)
+    [0.41176471, 1.0, 1.0]
+    """
+    cm = confusion_matrix(targets, predictions, sample_weights=sample_weights, normalize=None)
+    tp = np.diag(cm)
+    with np.errstate(all="warn"):
+        precision = tp / np.sum(cm, axis=0)
+
+    return np.nan_to_num(precision)

--- a/puma/utils/recall_score.py
+++ b/puma/utils/recall_score.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import numpy as np
+
+from puma.utils.confusion_matrix import confusion_matrix
+
+
+def recall_score_per_class(
+    targets: np.ndarray,
+    predictions: np.ndarray,
+    sample_weights: np.ndarray | None = None,
+) -> np.ndarray:
+    """
+    The recall score is defined, for each class, as ``tp / (tp + fn)`` where ``tp`` is the number of
+    true positives and ``fn`` is the number of false negatives.
+
+    Parameters
+    ----------
+    targets : 1d np.ndarray
+        target labels
+    predictions : 1d np.ndarray
+        predicted labels (output of the classifier)
+    sample_weights : np.ndarray, optional
+        Weight of each sample; if None, each sample weights the same. Defaults to None.
+
+    Returns
+    -------
+    np.ndarray : the per-class recall score.
+
+    Example
+    --------
+    >>> targets = np.array([2, 0, 2, 2, 0, 1])
+    >>> predictions = np.array([0, 0, 2, 2, 0, 2])
+    >>> weights = np.array([1, 0.5, 0.5, 1, 0.2, 1])
+    >>> recall_score_per_class(targets, predictions, sample_weights=weights)
+    [1.0, 0.0, 0.6]
+    """
+    cm = confusion_matrix(targets, predictions, sample_weights=sample_weights, normalize=None)
+
+    tp = np.diag(cm)
+    with np.errstate(all="warn"):
+        recall = tp / np.sum(cm, axis=1)
+
+    return np.nan_to_num(recall)


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Added functions to compute the per-class precision and recall scores
* Added the scores on the Track Origin's confusion matrix plot

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
