### PR TITLE
Improved control in high-level interface for auxiliary plots

### DIFF
--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -226,6 +226,7 @@ class AuxResults:
         xlabel: str = r"$p_{T}$ [GeV]",
         perf_var: str = "pt",
         incl_vertexing: bool = False,
+        vertex_match_requirement={'eff_req' : 0.65, 'purity_req' : 0.5},
         **kwargs,
     ):
         if vtx_flavours is None and no_vtx_flavours is None:
@@ -252,7 +253,7 @@ class AuxResults:
 
             # get cleaned vertex indices and calculate vertexing metrics
             truth_indices, reco_indices = tagger.vertex_indices(incl_vertexing=incl_vertexing)
-            vtx_metrics[tagger.name] = calculate_vertex_metrics(reco_indices, truth_indices)
+            vtx_metrics[tagger.name] = calculate_vertex_metrics(reco_indices, truth_indices, **vertex_match_requirement)
 
         if not vtx_metrics:
             raise ValueError("No taggers with vertexing aux task added.")

--- a/puma/utils/vertexing.py
+++ b/puma/utils/vertexing.py
@@ -130,8 +130,8 @@ def associate_vertices(test_vertices, ref_vertices, eff_req, purity_req):
     associations[common_tracks == 0] = False  # remove leftover pairs with zero matches
 
     # enforce purity and efficiency requirements
-    eff_cut = common_tracks * inv_ref_size > eff_req
-    purity_cut = common_tracks * inv_test_size > purity_req
+    eff_cut = common_tracks * inv_ref_size >= eff_req
+    purity_cut = common_tracks * inv_test_size >= purity_req
     associations = np.logical_and.reduce((associations, eff_cut, purity_cut))
 
     return associations, common_tracks


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Allows passing purity and recall requirements from the `plot_var_vtx_perf` to make it easier to make plots given different requirements
* Changes a requirement definition of recall/purtiy to now be `>=` instead of just `>` 


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
