### PR TITLE
Bump version to 0.3.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ### [Latest]
+
+### [v0.3.6] (2024/08/27)
+
 - Updated variable names for aux task outputs to be consistent with Salt [!270](https://github.com/umami-hep/puma/pull/270)
 - Merged precision and recall in one single function [!276](https://github.com/umami-hep/puma/pull/276)
 - Added functions for precision and recall scores [!275](https://github.com/umami-hep/puma/pull/275)

--- a/puma/__init__.py
+++ b/puma/__init__.py
@@ -2,7 +2,7 @@
 
 # flake8: noqa
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 from puma.histogram import Histogram, HistogramPlot
 from puma.integrated_eff import IntegratedEfficiency, IntegratedEfficiencyPlot


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Bump version to 0.3.6

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)