### PR TITLE
Distributions Pre/Post tag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### [Latest]
 
 - Added functionality to plot secondary vertex mass histograms using a pion mass hypothesis [!265](https://github.com/umami-hep/puma/pull/265)
+- Added new high-level api plot for distributions Pre/Post-tag [!279](https://github.com/umami-hep/puma/pull/279)
 
 ### [v0.3.6] (2024/08/27)
 

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -912,7 +912,13 @@ class Results:
             this_hist = hist_defaults.copy()
             flav_label = flav.label if flav != "inclusive" else "Inclusive"
             flav_name = flav.name if flav != "inclusive" else "inclusive"
-            this_hist["atlas_second_tag"] += f"\n{flav_label} Pre/Post-Tag at {working_point}% WP"
+
+            info_str = f"{flav_label} Pre/Post-Tag at {working_point}% WP"
+
+            if this_hist["atlas_second_tag"]:
+                this_hist["atlas_second_tag"] += f"\n{info_str}"
+            else:
+                this_hist["atlas_second_tag"] = info_str
             hist = HistogramPlot(**this_hist)
 
             for tagger in self.taggers.values():

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -868,7 +868,6 @@ class Results:
         suffix: str | None = None,
         x_var: str = "pt",
         xlabel: str = r"$p_{T}$ [GeV]",
-        exclude_tagger=None,
         **kwargs,
     ):
         """
@@ -885,8 +884,6 @@ class Results:
         xlabel : str, optional
             x-axis label, by default "$p_{T}$ [GeV]". If using a different x variable, you
             should probably change the label!
-        exclude_tagger : list, optional
-            List of taggers to be excluded from this plot, by default None
         **kwargs : kwargs
             key word arguments for `puma.HistogramPlot`
 
@@ -922,8 +919,6 @@ class Results:
             hist = HistogramPlot(**this_hist)
 
             for tagger in self.taggers.values():
-                if exclude_tagger is not None and tagger.name in exclude_tagger:
-                    continue
                 discs = tagger.discriminant(self.signal)
                 disc_cut = np.percentile(discs[tagger.is_flav(self.signal)], 100 - working_point)
 

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -64,7 +64,7 @@ class Results:
             "roc": self.plot_rocs,
             "peff": self.plot_var_perf,
             "scan": self.plot_fraction_scans,
-            'preposttag' : self.plot_preposttag
+            "preposttag": self.plot_preposttag,
         }
         self.saved_plots = []
 
@@ -864,23 +864,37 @@ class Results:
 
     def plot_preposttag(
         self,
+        working_point: float,
         suffix: str | None = None,
         x_var: str = "pt",
         xlabel: str = r"$p_{T}$ [GeV]",
-        working_point: float | None = None,
         exclude_tagger=None,
         **kwargs,
     ):
-        '''
-        Plot the distribution of a variable before and after the tagger cut
+        """
+        Plot the distribution of a variable before and after the tagger cut.
+
         Parameters
+        ----------
+        working_point: float, optional
+            The working point to use for the plot, by default None
+        suffix : str, optional
+            suffix to add to output file name, by default None
+        x_var : str, optional
+            The x axis variable, default is 'pt'
+        xlabel : str, optional
+            x-axis label, by default "$p_{T}$ [GeV]". If using a different x variable, you
+            should probably change the label!
+        exclude_tagger : list, optional
+            List of taggers to be excluded from this plot, by default None
+        **kwargs : kwargs
+            key word arguments for `puma.HistogramPlot`
 
-        '''
-
-        if x_var != 'pt' and xlabel == r"$p_{T}$ [GeV]":
+        """
+        if x_var != "pt" and xlabel == r"$p_{T}$ [GeV]":
             logger.warning(
-                "If using a different x variable, you should probably"
-                " change the label!")
+                "If using a different x variable, you should probably" " change the label!"
+            )
 
         line_styles = get_good_linestyles()
         hist_defaults = {
@@ -890,25 +904,25 @@ class Results:
             "figsize": (7.0, 4.5),
             "atlas_first_tag": self.atlas_first_tag,
             "atlas_second_tag": self.atlas_second_tag,
-            "y_scale" : 1.5
+            "y_scale": 1.5,
         }
         if kwargs is not None:
             hist_defaults.update(kwargs)
-        for flav in self.flavours + ['inclusive']:
+        for flav in [*self.flavours, "inclusive"]:
             this_hist = hist_defaults.copy()
-            flav_label = flav.label if flav != 'inclusive' else 'Inclusive'
-            flav_name = flav.name if flav != 'inclusive' else 'inclusive'
-            this_hist['atlas_second_tag'] += f"\n{flav_label} Pre/Post-Tag at {working_point}% WP"
+            flav_label = flav.label if flav != "inclusive" else "Inclusive"
+            flav_name = flav.name if flav != "inclusive" else "inclusive"
+            this_hist["atlas_second_tag"] += f"\n{flav_label} Pre/Post-Tag at {working_point}% WP"
             hist = HistogramPlot(**this_hist)
 
-            for i, tagger in enumerate(self.taggers.values()):
+            for tagger in self.taggers.values():
                 if exclude_tagger is not None and tagger.name in exclude_tagger:
                     continue
                 discs = tagger.discriminant(self.signal)
                 disc_cut = np.percentile(discs[tagger.is_flav(self.signal)], 100 - working_point)
-                
+
                 tagger_var = tagger.perf_vars[x_var]
-                if flav != 'inclusive':
+                if flav != "inclusive":
                     sel_flav = tagger.is_flav(flav)
                     discs = discs[sel_flav]
                     tagger_var = tagger_var[sel_flav]
@@ -934,13 +948,13 @@ class Results:
                 )
             hist.make_linestyle_legend(
                 linestyles=line_styles[:2],
-                labels=['Pre-tag', 'Post-tag'],
+                labels=["Pre-tag", "Post-tag"],
                 bbox_to_anchor=(0.55, 1),
             )
             hist.draw()
             fname = f"preposttag-{x_var}-{flav_name}-{working_point}WP"
             self.save(hist, "preposttag", fname, suffix)
-        
+
     def make_plot(self, plot_type, kwargs):
         """Make a plot.
 

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -894,11 +894,13 @@ class Results:
         }
         if kwargs is not None:
             hist_defaults.update(kwargs)
-        for flav in self.flavours:
+        for flav in self.flavours + ['inclusive']:
             this_hist = hist_defaults.copy()
-            
-            this_hist['atlas_second_tag'] += f"\n{flav.label} Pre/Post-Tag at {working_point}% WP"
+            flav_label = flav.label if flav != 'inclusive' else 'Inclusive'
+            flav_name = flav.name if flav != 'inclusive' else 'inclusive'
+            this_hist['atlas_second_tag'] += f"\n{flav_label} Pre/Post-Tag at {working_point}% WP"
             hist = HistogramPlot(**this_hist)
+
             for i, tagger in enumerate(self.taggers.values()):
                 if exclude_tagger is not None and tagger.name in exclude_tagger:
                     continue
@@ -906,9 +908,10 @@ class Results:
                 disc_cut = np.percentile(discs[tagger.is_flav(self.signal)], 100 - working_point)
                 
                 tagger_var = tagger.perf_vars[x_var]
-                sel_flav = tagger.is_flav(flav)
-                discs = discs[sel_flav]
-                tagger_var = tagger_var[sel_flav]
+                if flav != 'inclusive':
+                    sel_flav = tagger.is_flav(flav)
+                    discs = discs[sel_flav]
+                    tagger_var = tagger_var[sel_flav]
                 hist.add(
                     Histogram(
                         tagger_var,
@@ -935,7 +938,7 @@ class Results:
                 bbox_to_anchor=(0.55, 1),
             )
             hist.draw()
-            fname = f"preposttag-{x_var}-{flav.name}-{working_point}WP"
+            fname = f"preposttag-{x_var}-{flav_name}-{working_point}WP"
             self.save(hist, "preposttag", fname, suffix)
         
     def make_plot(self, plot_type, kwargs):

--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -138,8 +138,12 @@ class YumaConfig:
     @property
     def peff_vars(self):
         """Iterates plots and returns a list of all performance variables."""
-        peff_vars = list({p["plot_kwargs"].get("perf_var", "pt") for p in self.plots.get("peff", [])})
-        prepost_vars = list({p["plot_kwargs"].get("x_var", "pt") for p in self.plots.get("preposttag", [])})
+        peff_vars = list({
+            p["plot_kwargs"].get("perf_var", "pt") for p in self.plots.get("peff", [])
+        })
+        prepost_vars = list({
+            p["plot_kwargs"].get("x_var", "pt") for p in self.plots.get("preposttag", [])
+        })
         return list(set(peff_vars + prepost_vars))
 
     def make_plots(self, plot_types):

--- a/puma/hlplots/yuma.py
+++ b/puma/hlplots/yuma.py
@@ -12,7 +12,7 @@ from puma.hlplots import Results, Tagger, combine_suffixes, get_included_taggers
 from puma.hlplots.yutils import get_tagger_name
 from puma.utils import logger
 
-ALL_PLOTS = ["roc", "scan", "disc", "probs", "peff"]
+ALL_PLOTS = ["roc", "scan", "disc", "probs", "peff", "preposttag"]
 
 
 def get_args(args):
@@ -138,7 +138,9 @@ class YumaConfig:
     @property
     def peff_vars(self):
         """Iterates plots and returns a list of all performance variables."""
-        return list({p["plot_kwargs"].get("perf_var", "pt") for p in self.plots.get("peff", [])})
+        peff_vars = list({p["plot_kwargs"].get("perf_var", "pt") for p in self.plots.get("peff", [])})
+        prepost_vars = list({p["plot_kwargs"].get("x_var", "pt") for p in self.plots.get("preposttag", [])})
+        return list(set(peff_vars + prepost_vars))
 
     def make_plots(self, plot_types):
         """Makes all desired plots.

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -192,7 +192,10 @@ class ResultsPlotsTestCase(unittest.TestCase):
     def test_preposttag_plots(self):
         """Test that png file is being created."""
         self.dummy_tagger_1.reference = True
-        self.dummy_tagger_1.fxs = {"fc": 0.05}
+        rng = np.random.default_rng(seed=16)
+        self.dummy_tagger_1.perf_vars = {
+            "pt": rng.exponential(100, size=len(self.dummy_tagger_1.scores))
+        }
         with tempfile.TemporaryDirectory() as tmp_file:
             results = Results(signal="bjets", sample="test", output_dir=tmp_file)
             results.add(self.dummy_tagger_1)

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -189,6 +189,18 @@ class ResultsPlotsTestCase(unittest.TestCase):
         dummy_tagger_1.label = "dummy tagger"
         self.dummy_tagger_1 = dummy_tagger_1
 
+    def test_preposttag_plots(self):
+        """Test that png file is being created."""
+        self.dummy_tagger_1.reference = True
+        self.dummy_tagger_1.fxs = {"fc": 0.05}
+        with tempfile.TemporaryDirectory() as tmp_file:
+            results = Results(signal="bjets", sample="test", output_dir=tmp_file)
+            results.add(self.dummy_tagger_1)
+            results.plot_preposttag(70)
+            for fpath in results.saved_plots:
+                assert fpath.is_file()
+            results.saved_plots = []
+    
     def test_plot_probs_bjets(self):
         """Test that png file is being created."""
         self.dummy_tagger_1.reference = True

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -200,7 +200,7 @@ class ResultsPlotsTestCase(unittest.TestCase):
             for fpath in results.saved_plots:
                 assert fpath.is_file()
             results.saved_plots = []
-    
+
     def test_plot_probs_bjets(self):
         """Test that png file is being created."""
         self.dummy_tagger_1.reference = True

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -202,6 +202,11 @@ class ResultsPlotsTestCase(unittest.TestCase):
             results.plot_preposttag(70)
             for fpath in results.saved_plots:
                 assert fpath.is_file()
+
+            # Check the tag doesn't break if second tag is None
+            results.atlas_second_tag = None
+            results.plot_preposttag(70)
+
             results.saved_plots = []
 
     def test_plot_probs_bjets(self):


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Adds a new plot to the high level interface, pre/post tag
* This plots a given jet-level distribution before and after a tagger working point has been applied.


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
