### PR TITLE
Upgrade atlas-ftag-tools version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Upgrade atlas-ftag-tools version [!297](https://github.com/umami-hep/puma/pull/297)
+
 ### [v0.4.1] (2024/11/18)
 - Update tools package version [!296](https://github.com/umami-hep/puma/pull/296)
 - Adding functions to process truth hadron information and associate tracks to hadrons [!285](https://github.com/umami-hep/puma/pull/285)

--- a/puma/__init__.py
+++ b/puma/__init__.py
@@ -2,7 +2,7 @@
 
 # flake8: noqa
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from puma.histogram import Histogram, HistogramPlot
 from puma.integrated_eff import IntegratedEfficiency, IntegratedEfficiencyPlot

--- a/puma/__init__.py
+++ b/puma/__init__.py
@@ -2,7 +2,7 @@
 
 # flake8: noqa
 
-__version__ = "0.4.2"
+__version__ = "0.4.1"
 
 from puma.histogram import Histogram, HistogramPlot
 from puma.integrated_eff import IntegratedEfficiency, IntegratedEfficiencyPlot

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ scipy==1.10.1
 tables==3.8.0
 testfixtures==7.0.0
 palettable==3.3.0
-atlas-ftag-tools==0.2.7
+atlas-ftag-tools==0.2.8


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Upgrade [atlas-ftag-tools](https://github.com/umami-hep/atlas-ftag-tools) version to v0.2.8
* Bump version for new release to incorporate changes from [atlas-ftag-tools](https://github.com/umami-hep/atlas-ftag-tools)

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
