### PR TITLE
Default to pdf plots in the HLAPI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Use pdf plots by default in the HLAPI [!299](https://github.com/umami-hep/puma/pull/299)
+
 ### [v0.4.3] (2025/01/31)
 
 - Fixing ratio/uncertainty calculation issue for Data/MC histograms [!298](https://github.com/umami-hep/puma/pull/298)

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -33,7 +33,7 @@ class AuxResults:
     perf_vars: str | tuple | list = "pt"
     aux_perf_vars: str | tuple | list = None
     output_dir: str | Path = "."
-    extension: str = "png"
+    extension: str = "pdf"
     global_cuts: Cuts | list | None = None
     num_jets: int | None = None
     remove_nan: bool = False

--- a/puma/hlplots/results.py
+++ b/puma/hlplots/results.py
@@ -41,7 +41,7 @@ class Results:
     taggers: dict = field(default_factory=dict)
     perf_vars: str | tuple | list = "pt"
     output_dir: str | Path = "."
-    extension: str = "png"
+    extension: str = "pdf"
     global_cuts: Cuts | list | None = None
     num_jets: int | None = None
     remove_nan: bool = False
@@ -331,6 +331,13 @@ class Results:
 
         # Get a list of all flavours which are present
         flavours = [*self.backgrounds, self.signal]
+
+        # Remove any flavours that are not used by all taggers
+        flavours = [
+            flav
+            for flav in flavours
+            if all(flav in tagger.output_flavours for tagger in self.taggers.values())
+        ]
 
         # Init a default kwargs dict for the HistogramPlot
         histo_kwargs = {

--- a/puma/tests/hlplots/test_yuma.py
+++ b/puma/tests/hlplots/test_yuma.py
@@ -147,7 +147,7 @@ class TestYumaPlots(unittest.TestCase):
             ctagging = out_dir / "ctag"
             assert btagging.exists(), "No b-tagging plots produced"
             assert not ctagging.exists(), "No c-tagging plots should have been produced"
-            btag_plots = [p.name for p in btagging.rglob("*.png")]
+            btag_plots = [p.name for p in btagging.rglob("*.pdf")]
             assert len(btag_plots) == 22, f"Expected 22 b-tagging plot, found {len(btag_plots)}"
 
             args = [
@@ -160,7 +160,7 @@ class TestYumaPlots(unittest.TestCase):
             ]
             main(args)
 
-            ctag_plots = [p.name for p in ctagging.rglob("*.png")]
+            ctag_plots = [p.name for p in ctagging.rglob("*.pdf")]
             assert ctagging.exists(), "No c-tagging plots produced"
             assert (
                 len(ctag_plots) == 1
@@ -200,6 +200,6 @@ class TestYumaPlots(unittest.TestCase):
             ctagging = out_dir / "ctag"
             assert btagging.exists(), "No b-tagging plots produced"
             assert not ctagging.exists(), "No c-tagging plots should have been produced"
-            btag_plots = [p.name for p in btagging.rglob("*.png")]
+            btag_plots = [p.name for p in btagging.rglob("*.pdf")]
             print(btag_plots)
             assert len(btag_plots) == 3, f"Expected 3 b-tagging plot, found {len(btag_plots)}"


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Use pdfs by default in the HLAPI

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
