### PR TITLE
Fixing ratio calculation issue when using no error band

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Fixing ratio calculation issue when using no error band [!302](https://github.com/umami-hep/puma/pull/302)
+- Update y-axis label to accomodate british english [!300](https://github.com/umami-hep/puma/pull/300)
 - Use pdf plots by default in the HLAPI [!299](https://github.com/umami-hep/puma/pull/299)
 
 ### [v0.4.3] (2025/01/31)

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -576,13 +576,13 @@ class HistogramPlot(PlotBase):
                 **kwargs,
             )
 
-        # Check if errors should be drawn
-        # If stacked is true, plot the combined uncertainty
-        if self.draw_errors and self.stacked:
-            # Create a total weights entry to correctly plot the error band
+            # Create a total weights entry to correctly plot the ratio
             # Total weights is here the y-value of all contributions stacked
             self.stacked_dict["total_weights"] = np.sum(self.stacked_dict["weights"], axis=0)
 
+        # Check if errors should be drawn
+        # If stacked is true, plot the combined uncertainty
+        if self.draw_errors and self.stacked:
             # Calculate the y-values of the bottom error
             bottom_error = self.stacked_dict["total_weights"] - self.stacked_dict["unc"]
             bottom_error = np.array([bottom_error[0], *bottom_error.tolist()])


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fixes an issue when using the stacked histograms without error bars

Relates to the following issues

* Closes #301

Tagging @jackerschott

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
