### PR TITLE
Small fixes and improvements for vertexing plots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Small improvements for vertexing plots [!305](https://github.com/umami-hep/puma/pull/305)
+
 ### [v0.4.4] (2025/02/17)
 
 - Adding show() function support [!304](https://github.com/umami-hep/puma/pull/304)

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -300,7 +300,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag + f", {flav.label}\n{vtx_match_str}",
+                atlas_second_tag=atlas_second_tag + f", {flav.label.lower()}\n{vtx_match_str}",
                 y_scale=1.4,
             )
             # $n_{vtx}^{match}/n_{vtx}^{reco}$
@@ -310,7 +310,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag + f", {flav.label}\n{vtx_match_str}",
+                atlas_second_tag=atlas_second_tag + f", {flav.label.lower()}\n{vtx_match_str}",
                 y_scale=1.4,
             )
             # $n_{trk}^{match}/n_{trk}^{true}$
@@ -320,7 +320,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag + f", {flav.label}",
+                atlas_second_tag=atlas_second_tag + f", {flav.label.lower()}",
                 y_scale=1.4,
             )
             # $n_{trk}^{match}/n_{trk}^{reco}$
@@ -463,9 +463,12 @@ class AuxResults:
                 xlabel="$m_{SV}$ [GeV]",
                 ylabel="Normalised number of vertices",
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag + f"\n{vertexing_text} vertexing, {flav.label}",
+                atlas_second_tag=atlas_second_tag
+                + f"\n{vertexing_text} vertexing, {flav.label.lower()}",
                 y_scale=1.7,
                 n_ratio_panels=1,
+                ymin_ratio=[0.8],
+                ymax_ratio=[1.4],
                 **kwargs,
             )
 
@@ -476,7 +479,7 @@ class AuxResults:
                     ylabel="Normalised number of vertices",
                     atlas_first_tag=self.atlas_first_tag,
                     atlas_second_tag=atlas_second_tag
-                    + f"\n{vertexing_text} vertexing, {flav.label}",
+                    + f"\n{vertexing_text} vertexing, {flav.label.lower()}",
                     y_scale=1.4,
                     **kwargs,
                 )

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -275,13 +275,15 @@ class AuxResults:
         vtx_metrics = {}
         for tagger in self.taggers.values():
             if "vertexing" not in tagger.aux_tasks:
-                logger.warning(f"{tagger.name} does not have vertexing aux task defined. Skipping.")
-            assert perf_var in tagger.perf_vars, f"{perf_var} not in tagger {tagger.name} data!"
+                logger.warning(
+                    f"{tagger.label} does not have vertexing aux task defined. Skipping."
+                )
+            assert perf_var in tagger.perf_vars, f"{perf_var} not in tagger {tagger.label} data!"
 
             # get cleaned vertex indices and calculate vertexing metrics
             truth_indices, reco_indices = tagger.vertex_indices(incl_vertexing=incl_vertexing)
             max_vertices = 20 if not incl_vertexing else 1
-            vtx_metrics[tagger.name] = calculate_vertex_metrics(
+            vtx_metrics[tagger.label] = calculate_vertex_metrics(
                 reco_indices, truth_indices, max_vertices=max_vertices, **vertex_match_requirement
             )
 
@@ -330,21 +332,21 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag + f", {flav.label}",
+                atlas_second_tag=atlas_second_tag + f", {flav.label.lower()}",
                 y_scale=1.4,
             )
 
             for tagger in self.taggers.values():
-                if tagger.name not in vtx_metrics:
+                if tagger.label not in vtx_metrics:
                     continue
                 is_flavour = tagger.is_flav(flav)
-                include_sum = vtx_metrics[tagger.name]["track_overlap"][is_flavour] >= 0
+                include_sum = vtx_metrics[tagger.label]["track_overlap"][is_flavour] >= 0
 
                 vtx_perf = VarVsVtx(
                     x_var=tagger.perf_vars[perf_var][is_flavour],
-                    n_match=vtx_metrics[tagger.name]["n_match"][is_flavour],
-                    n_true=vtx_metrics[tagger.name]["n_ref"][is_flavour],
-                    n_reco=vtx_metrics[tagger.name]["n_test"][is_flavour],
+                    n_match=vtx_metrics[tagger.label]["n_match"][is_flavour],
+                    n_true=vtx_metrics[tagger.label]["n_ref"][is_flavour],
+                    n_reco=vtx_metrics[tagger.label]["n_test"][is_flavour],
                     label=tagger.label,
                     colour=tagger.colour,
                     **kwargs,
@@ -352,17 +354,17 @@ class AuxResults:
                 vtx_trk_perf = VarVsVtx(
                     x_var=tagger.perf_vars[perf_var][is_flavour],
                     n_match=np.sum(
-                        vtx_metrics[tagger.name]["track_overlap"][is_flavour],
+                        vtx_metrics[tagger.label]["track_overlap"][is_flavour],
                         axis=1,
                         where=include_sum,
                     ),
                     n_true=np.sum(
-                        vtx_metrics[tagger.name]["ref_vertex_size"][is_flavour],
+                        vtx_metrics[tagger.label]["ref_vertex_size"][is_flavour],
                         axis=1,
                         where=include_sum,
                     ),
                     n_reco=np.sum(
-                        vtx_metrics[tagger.name]["test_vertex_size"][is_flavour],
+                        vtx_metrics[tagger.label]["test_vertex_size"][is_flavour],
                         axis=1,
                         where=include_sum,
                     ),
@@ -397,24 +399,24 @@ class AuxResults:
 
             plot_vtx_fakes = VarVsVtxPlot(
                 mode="fakes",
-                ylabel="Fake Rate",
+                ylabel="Vertex rate",
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag + f", {flav.label}",
+                atlas_second_tag=atlas_second_tag + f", {flav.label.lower()}",
                 y_scale=1.4,
             )
 
             for tagger in self.taggers.values():
-                if tagger.name not in vtx_metrics:
+                if tagger.label not in vtx_metrics:
                     continue
                 is_flavour = tagger.is_flav(flav)
 
                 vtx_perf = VarVsVtx(
                     x_var=tagger.perf_vars[perf_var][is_flavour],
-                    n_match=vtx_metrics[tagger.name]["n_match"][is_flavour],
-                    n_true=vtx_metrics[tagger.name]["n_ref"][is_flavour],
-                    n_reco=vtx_metrics[tagger.name]["n_test"][is_flavour],
+                    n_match=vtx_metrics[tagger.label]["n_match"][is_flavour],
+                    n_true=vtx_metrics[tagger.label]["n_ref"][is_flavour],
+                    n_reco=vtx_metrics[tagger.label]["n_test"][is_flavour],
                     label=tagger.label,
                     colour=tagger.colour,
                     **kwargs,
@@ -487,7 +489,7 @@ class AuxResults:
             for i, tagger in enumerate(self.taggers.values()):
                 if "vertexing" not in tagger.aux_tasks:
                     logger.warning(
-                        f"{tagger.name} does not have vertexing aux task defined. Skipping."
+                        f"{tagger.label} does not have vertexing aux task defined. Skipping."
                     )
 
                 assert {"pt", "eta", "dphi"}.issubset(
@@ -628,5 +630,5 @@ class AuxResults:
                     **kwargs,
                 )
             plot_cm.draw(cm)
-            base = tagger.name + "_trackOrigin_cm"
+            base = tagger.label + "_trackOrigin_cm"
             plot_cm.savefig(self.get_filename(base))

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -316,7 +316,7 @@ class AuxResults:
             # $n_{trk}^{match}/n_{trk}^{true}$
             plot_vtx_trk_eff = VarVsVtxPlot(
                 mode="efficiency",
-                ylabel="Track Assignment Efficiency",
+                ylabel="Track assignment efficiency",
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
@@ -326,7 +326,7 @@ class AuxResults:
             # $n_{trk}^{match}/n_{trk}^{reco}$
             plot_vtx_trk_purity = VarVsVtxPlot(
                 mode="purity",
-                ylabel="Track Assignment Purity",
+                ylabel="Track assignment purity",
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -261,6 +261,9 @@ class AuxResults:
 
         if vertex_match_requirement is None:
             vertex_match_requirement = {"eff_req": 0.65, "purity_req": 0.5}
+            # if you want to make the track level recall and purity plots,
+            # don't require any quality requirements
+            # vertex_match_requirement = {"eff_req": 0, "purity_req": 0}
         eff_req = round(vertex_match_requirement["eff_req"] * 100, 1)
         purity_req = round(vertex_match_requirement["purity_req"] * 100, 1)
         vtx_match_str = rf"Recall $\geq {eff_req}\%$, Purity $\geq {purity_req}\%$"
@@ -277,8 +280,9 @@ class AuxResults:
 
             # get cleaned vertex indices and calculate vertexing metrics
             truth_indices, reco_indices = tagger.vertex_indices(incl_vertexing=incl_vertexing)
+            max_vertices = 20 if not incl_vertexing else 1
             vtx_metrics[tagger.name] = calculate_vertex_metrics(
-                reco_indices, truth_indices, **vertex_match_requirement
+                reco_indices, truth_indices, max_vertices=max_vertices, **vertex_match_requirement
             )
 
         if not vtx_metrics:
@@ -316,7 +320,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag + f", {flav.label}\n{vtx_match_str}",
+                atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
             # $n_{trk}^{match}/n_{trk}^{reco}$
@@ -326,7 +330,7 @@ class AuxResults:
                 xlabel=xlabel,
                 logy=False,
                 atlas_first_tag=self.atlas_first_tag,
-                atlas_second_tag=atlas_second_tag + f", {flav.label}\n{vtx_match_str}",
+                atlas_second_tag=atlas_second_tag + f", {flav.label}",
                 y_scale=1.4,
             )
 

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -630,5 +630,6 @@ class AuxResults:
                     **kwargs,
                 )
             plot_cm.draw(cm)
-            base = tagger.label + "_trackOrigin_cm"
+            base = tagger.name + "_trackOrigin_cm"
             plot_cm.savefig(self.get_filename(base))
+            print("saved file with name", self.get_filename(base))

--- a/puma/hlplots/tagger.py
+++ b/puma/hlplots/tagger.py
@@ -42,6 +42,7 @@ class Tagger:
     )
     disc_cut: float = None
     working_point: float = None
+    vertexing_require_hf_track: bool = True
 
     # Used only by YUMA
     yaml_name: str = None
@@ -269,7 +270,10 @@ class Tagger:
                 else self.aux_scores["track_origin"][i]
             )
             reco_indices[i] = clean_reco_vertices(
-                reco_indices[i], reco_track_origin, incl_vertexing=incl_vertexing
+                reco_indices[i],
+                reco_track_origin,
+                incl_vertexing=incl_vertexing,
+                require_hf_track=self.vertexing_require_hf_track,
             )
 
         return truth_indices, reco_indices

--- a/puma/utils/vertexing.py
+++ b/puma/utils/vertexing.py
@@ -227,10 +227,13 @@ def calculate_vertex_metrics(
         max_index = min(metrics["n_match"][i], max_vertices)
 
         # write out vertexing purity metrics
-        # assert (common_tracks[associations] == common_tracks).all()
-        metrics["track_overlap"][i, :max_index] = common_tracks[:, :max_index]
-        metrics["test_vertex_size"][i, :max_index] = test_vertices.sum(axis=1)[:max_index]
-        metrics["ref_vertex_size"][i, :max_index] = ref_vertices.sum(axis=1)[:max_index]
+        metrics["track_overlap"][i, :max_index] = common_tracks[associations][:max_index]
+        metrics["test_vertex_size"][i, :max_index] = test_vertices[
+            associations.sum(axis=1).astype(bool)
+        ].sum(axis=1)[:max_index]
+        metrics["ref_vertex_size"][i, :max_index] = ref_vertices[
+            associations.sum(axis=0).astype(bool)
+        ].sum(axis=1)[:max_index]
 
     return metrics
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* add a comment about producing track assignment recall and purity plots (should disable vertex quality requirements)
* improve atlas tag format
* add option to disable only the heavy flavour track requirement for GN2


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
