### PR TITLE
Minor update to confusion matrix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Minor change to how n_classes are calculated in confusion matrix [!306](https://github.com/umami-hep/puma/pull/306)
+
 ### [v0.4.4] (2025/02/17)
 
 - Adding show() function support [!304](https://github.com/umami-hep/puma/pull/304)

--- a/puma/utils/confusion_matrix.py
+++ b/puma/utils/confusion_matrix.py
@@ -59,8 +59,7 @@ def confusion_matrix(
         }, "confusion_matrix: invalid normalization keyword"
 
     # Finding number of target classes
-    # (i.e. max value of the categorical indexing plus one,
-    # since categorical index starts from zero)
+    # (i.e. unique elements across targets and predictions) 
     n_classes = np.unique(np.concatenate((targets, predictions))).size
 
     # If no samples' weights are given, give to each sample weight = 1

--- a/puma/utils/confusion_matrix.py
+++ b/puma/utils/confusion_matrix.py
@@ -61,7 +61,7 @@ def confusion_matrix(
     # Finding number of target classes
     # (i.e. max value of the categorical indexing plus one,
     # since categorical index starts from zero)
-    n_classes = int(np.max(targets)) + 1
+    n_classes = np.unique(np.concatenate((targets, predictions))).size
 
     # If no samples' weights are given, give to each sample weight = 1
     if sample_weights is None:

--- a/puma/utils/confusion_matrix.py
+++ b/puma/utils/confusion_matrix.py
@@ -59,7 +59,7 @@ def confusion_matrix(
         }, "confusion_matrix: invalid normalization keyword"
 
     # Finding number of target classes
-    # (i.e. unique elements across targets and predictions) 
+    # (i.e. unique elements across targets and predictions)
     n_classes = np.unique(np.concatenate((targets, predictions))).size
 
     # If no samples' weights are given, give to each sample weight = 1


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Adds some extra flexibility to the confusion matrix code if labels are non-consecutive or some label categories are missing completely in either true or predicted arrays.

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
