### PR TITLE
Bump atlas-ftag-tools to v0.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ scipy==1.10.1
 tables==3.8.0
 testfixtures==7.0.0
 palettable==3.3.0
-atlas-ftag-tools==0.2.8
+atlas-ftag-tools==0.2.9


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Bumping version of `atlas-ftag-tools` to v0.2.9

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/puma/)
