### PR TITLE
Enable docker build for latest only on main

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   build_latest:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -27,12 +28,10 @@ jobs:
         run: docker build -f docker/Dockerfile --tag ${GITLAB_CONTAINER_REGISTRY}/puma:latest .
 
       - name: Login to GitLab container registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: docker login gitlab-registry.cern.ch -u ${{ secrets.GITLAB_USERNAME }} -p ${{ secrets.GITLAB_TOKEN }}
 
       # Push this image if this is on the main branch
       - name: Push image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: docker push ${GITLAB_CONTAINER_REGISTRY}/puma:latest
 
   build_release:


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Disables the building of the docker image in PRs.
* The latest docker image is now only build for main 

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
