### PR TITLE
Update atlas-ftag-tools package

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 
 ### [v0.4.7] (2025/06/17)
 
+- Update atlas-ftag-tools package [!326](https://github.com/umami-hep/puma/pull/326)
 - Adding save/load functionality to VarVsVar and VarVsEff [!324](https://github.com/umami-hep/puma/pull/324)
 - Enable docker build for latest only on main [!325](https://github.com/umami-hep/puma/pull/325)
 - Adding option to define the plot layout [!323](https://github.com/umami-hep/puma/pull/323)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ scipy>=1.15.2
 tables>=3.10.1
 testfixtures==7.0.0
 palettable==3.3.0
-atlas-ftag-tools==0.2.11
+atlas-ftag-tools==0.2.12


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update `atlas-ftag-tools` to `v0.2.12`

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
