### PR TITLE
Bumping atlas-ftag-tools version to v0.2.13

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Bumping atlas-ftag-tools version to v0.2.13 [!329](https://github.com/umami-hep/puma/pull/329)
 - Puma Tutorial Fixes [!328](https://github.com/umami-hep/puma/pull/328)
 - Update Puma Tutorial to newest Standards [!327](https://github.com/umami-hep/puma/pull/327)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
+atlas-ftag-tools==0.2.13
 atlasify==0.8.0
 coverage==6.3.1
 h5py>=3.13.0
 ipython==8.32.0
 matplotlib==3.9.2
 numpy>=2.2.4
+palettable==3.3.0
 pandas>=2.2.3
 pre-commit==3.5.0
 pydot==1.4.2
@@ -14,5 +16,3 @@ pyyaml-include==1.3
 scipy>=1.15.2
 tables>=3.10.1
 testfixtures==7.0.0
-palettable==3.3.0
-atlas-ftag-tools==0.2.12


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Bump `atlas-ftag-tools` version to `v0.2.13`

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
