### PR TITLE
Updating atlas-ftag-tools to v0.2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-atlas-ftag-tools==0.2.13
+atlas-ftag-tools==0.2.14
 atlasify==0.8.0
 coverage==6.3.1
 h5py>=3.13.0


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update `atlas-ftag-tools` to [`v0.2.14`](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.2.14)

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
