### PR TITLE
Update atlas-ftag-tools Version to v0.2.15

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update atlas-ftag-tools Version to v0.2.15 [#335](https://github.com/umami-hep/puma/pull/335)
 - Updating Docstrings and skipped pre-commit checks [#332](https://github.com/umami-hep/puma/pull/332)
 - Update Repository Metadata [#331](https://github.com/umami-hep/puma/pull/331)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-atlas-ftag-tools==0.2.14
+atlas-ftag-tools==0.2.15
 atlasify==0.8.0
 coverage==6.3.1
 h5py>=3.13.0


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update `atlas-ftag-tools` Version to `v0.2.15`

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
