### PR TITLE
Adding Iterative Filling for Histogram Class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Adding Iterative Filling for Histogram Class [#337]
 - Reneable `mypy` [#333](https://github.com/umami-hep/puma/pull/333)
 - Adding `subtract` Method in `VarVsVar` class [#336](https://github.com/umami-hep/puma/pull/336)
 

--- a/docs/examples/histograms.md
+++ b/docs/examples/histograms.md
@@ -2,7 +2,7 @@
 
 The following examples use the dummy data which is described [here](./dummy_data.md)
 
-## _b_-tagging discriminant plot
+## _b_-tagging Discriminant Plot
 
 <img src=https://github.com/umami-hep/puma/raw/examples-material/histogram_discriminant.png width=500>
 
@@ -10,7 +10,7 @@ The following examples use the dummy data which is described [here](./dummy_data
 --8<-- "examples/plot_discriminant_scores.py"
 ```
 
-## Flavour probabilities plot
+## Flavour Probabilities Plot
 
 <img src=https://github.com/umami-hep/puma/raw/examples-material/histogram_bjets_probability.png width=500>
 
@@ -18,7 +18,7 @@ The following examples use the dummy data which is described [here](./dummy_data
 --8<-- "examples/plot_flavour_probabilities.py"
 ```
 
-## More general example
+## More General Example
 
 In most cases you probably want to plot histograms with the different flavours
 like in the examples above.
@@ -31,7 +31,7 @@ could also produce a `MC` vs `data` plot with the following example code:
 --8<-- "examples/plot_basic_histogram.py"
 ```
 
-## Weighted histograms
+## Weighted Histograms
 
 `puma` also supports weighted histograms by specifying the optional argument `weights`.
 An example is given below:
@@ -42,7 +42,7 @@ An example is given below:
 --8<-- "examples/plot_weighted_histograms.py"
 ```
 
-## Underflow/overflow bins
+## Underflow/Overflow Bins
 
 Underflow and overflow bins are enabled by default, but can be deactivated using the
 `underoverflow` attribute of `puma.HistogramPlot`.
@@ -56,7 +56,18 @@ underflow/overflow bins.
 --8<-- "examples/plot_histogram_underoverflow.py"
 ```
 
-## Data/MC histograms
+## Iteratively Filling a Histogram
+
+Sometimes, the amount of data/jets you want to histogram, is too large to fit in your RAM. To avoid issues here,
+you can use the `update()` function of the `Histogram` class.
+
+<img src=https://github.com/umami-hep/puma/raw/examples-material/Iterative_histogram.png width=500>
+
+```py
+--8<-- "examples/plot_iterative_histogram.py"
+```
+
+## Data/MC Histograms
 
 To visualize the agreement of the Monte-Carlo with data, `puma` is also able to produce
 so-called Data/MC histograms. They show the data as a dot histogram while the MC is still

--- a/examples/plot_basic_histogram.py
+++ b/examples/plot_basic_histogram.py
@@ -16,7 +16,7 @@ measurement = np.concatenate((
     rng.normal(loc=2, scale=0.2, size=N_SIG),
 ))
 expectation_hist = Histogram(
-    expectation,
+    values=expectation,
     bins=50,
     bins_range=(1.1, 4),
     norm=False,
@@ -25,7 +25,7 @@ expectation_hist = Histogram(
     alpha=1,
 )
 measurement_hist = Histogram(
-    measurement,
+    values=measurement,
     bins=50,
     bins_range=(1.1, 4),
     norm=False,

--- a/examples/plot_histograms_from_files.py
+++ b/examples/plot_histograms_from_files.py
@@ -20,11 +20,13 @@ histo = Histogram(
 )
 histo.save("test_histo.yaml")
 
+# Create the HistogramPlot and add the still-loaded Histogram object
 plot = HistogramPlot()
 plot.add(histo)
 plot.draw()
 plot.savefig("fresh_histogram.png")
 
+# Load the Histogram and create a new plot with it
 loaded_histo = Histogram.load("test_histo.yaml")
 loaded_histo_plot = HistogramPlot()
 loaded_histo_plot.add(loaded_histo)

--- a/examples/plot_iterative_histogram.py
+++ b/examples/plot_iterative_histogram.py
@@ -1,0 +1,42 @@
+"""Example script that demonstrates iterative Histogram filling."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from puma import Histogram, HistogramPlot
+
+rng = np.random.default_rng(42)
+
+# We create now two value sets to mimic a batch-wise loading
+vals = rng.normal(size=10_000)
+extra_vals = rng.normal(size=10_000)
+
+# We can also define weights for each entry. For simplicity, we set them to one for this example
+weights_vals = np.ones_like(vals)
+weights_extra_vals = np.ones_like(extra_vals)
+
+# Now loop over our batches
+for counter, (batch_values, batch_weights) in enumerate(
+    zip([vals, extra_vals], [weights_vals, weights_extra_vals])
+):
+    # Create the histogram if it's the first batch
+    if counter == 0:
+        histo = Histogram(
+            values=batch_values,
+            weights=batch_weights,
+            bins=40,
+            bins_range=(-2, 2),
+            underoverflow=False,
+            label="Gaussian($\\mu=0$, $\\sigma=1$)",
+        )
+
+    # Update the existing histogram else
+    else:
+        histo.update(values=batch_values, weights=batch_weights)
+
+# Create the HistogramPlot and add the iterativly filled histogram
+plot = HistogramPlot()
+plot.add(histo)
+plot.draw()
+plot.savefig("Iterative_histogram.png")

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -151,8 +151,8 @@ class Histogram(PlotLineObject):
         self.flavour = Flavours[flavour] if isinstance(flavour, str) else flavour
 
         # Set the inputs as attributes
-        self.weights = weights or np.ones_like(values)
-        self.sum_of_weights = float(np.sum(weights))
+        self.weights = weights if weights is not None else np.ones_like(values)
+        self.sum_of_weights = float(np.sum(self.weights))
         self.ratio_group = ratio_group
         self.add_flavour_label = add_flavour_label
         self.histtype = histtype

--- a/puma/histogram.py
+++ b/puma/histogram.py
@@ -126,23 +126,23 @@ class Histogram(PlotLineObject):
         if weights is not None and len(values) != len(weights):
             raise ValueError("`values` and `weights` are not of same length.")
 
-        self.bins = bins
-        self.bins_range = bins_range
-        self.bin_edges = bin_edges
-        self.sum_squared_weights = sum_squared_weights
-        self.kwargs = kwargs
-
-        if self.bin_edges is None and self.sum_squared_weights is not None:
+        if bin_edges is None and sum_squared_weights is not None:
             logger.warning(
                 "The Histogram has no bin edges defined and is thus not considered filled. "
                 "Parameter `sum_squared_weights` is ignored."
             )
 
-        elif self.bin_edges is not None and self.bins is not None:
+        elif bin_edges is not None and bins is not None:
             logger.warning("When bin_edges are provided, bins are not considered!")
 
-        elif self.bin_edges is None and self.bins is None:
+        elif bin_edges is None and bins is None:
             raise ValueError("You need to define either `bins` or `bin_edges`!")
+
+        self.bins = bins
+        self.bins_range = bins_range
+        self.bin_edges = bin_edges
+        self.sum_squared_weights = sum_squared_weights
+        self.kwargs = kwargs
 
         # This attribute allows to know how to histogram it
         self.filled = self.bin_edges is not None
@@ -151,7 +151,8 @@ class Histogram(PlotLineObject):
         self.flavour = Flavours[flavour] if isinstance(flavour, str) else flavour
 
         # Set the inputs as attributes
-        self.weights = weights
+        self.weights = weights or np.ones_like(values)
+        self.sum_of_weights = float(np.sum(weights))
         self.ratio_group = ratio_group
         self.add_flavour_label = add_flavour_label
         self.histtype = histtype
@@ -231,8 +232,59 @@ class Histogram(PlotLineObject):
             "label": self.label,
             "norm": self.norm,
             "discrete_vals": self.discrete_vals,
+            "sum_of_weights": self.sum_of_weights,
             **extra_kwargs,
         }
+
+    def update(self, values: np.ndarray, weights: np.ndarray | None = None) -> None:
+        """Update the existing histogram with new values.
+
+        Parameters
+        ----------
+        values : np.ndarray
+            New values that are to be added.
+        weights : np.ndarray | None, optional
+            Weights for each entry in values. Must be the same shape/size as values.
+            If None, each value in values will be weighted the same, by default None
+        """
+        # Replace the weights if None
+        if weights is None:
+            weights = np.ones_like(values)
+
+        # Check that the weights are a np.ndarray
+        assert isinstance(weights, np.ndarray)
+
+        # Call the hist_w_unc function for the new values
+        _, incoming_hist, incoming_unc, _ = hist_w_unc(
+            arr=values,
+            bins=self.bins,
+            filled=self.filled,
+            bins_range=self.bins_range,
+            normed=self.norm,
+            weights=weights,
+            bin_edges=self.bin_edges,
+            sum_squared_weights=self.sum_squared_weights,
+            underoverflow=self.underoverflow,
+        )
+
+        # Get the new sum_of_weights
+        incoming_sum_of_weights = float(np.sum(weights))
+
+        if self.norm:
+            self.hist = (
+                self.hist * self.sum_of_weights + incoming_hist * incoming_sum_of_weights
+            ) / (self.sum_of_weights + incoming_sum_of_weights)
+            self.unc = np.sqrt(
+                (self.unc * self.sum_of_weights) ** 2
+                + (incoming_unc * incoming_sum_of_weights) ** 2
+            ) / (self.sum_of_weights + incoming_sum_of_weights)
+
+        else:
+            self.hist += incoming_hist
+            self.unc = np.sqrt(self.unc**2 + incoming_unc**2)
+
+        self.sum_of_weights += incoming_sum_of_weights
+        self.band = self.hist - self.unc
 
     def divide(self, other):
         """Calculate ratio between two class objects.

--- a/puma/tests/test_histogram.py
+++ b/puma/tests/test_histogram.py
@@ -162,6 +162,64 @@ class HistogramTestCase(unittest.TestCase):
             "Expected warning not found",
         )
 
+    def test_update_behaviour_without_weights_no_norm(self):
+        """Test the default behaviour of update without weights and no norm."""
+        hist = Histogram(
+            values=[1, 1, 1, 2, 2],
+            bins=np.array([1, 2, 3]),
+            norm=False,
+        )
+        hist.update(values=np.array([2, 2, 2]))
+        np.testing.assert_array_equal(hist.hist, np.array([3, 5]))
+        np.testing.assert_array_almost_equal(hist.unc, np.sqrt(np.array([3, 5])))
+        np.testing.assert_array_almost_equal(
+            hist.band, np.array([3, 5]) - np.sqrt(np.array([3, 5]))
+        )
+
+    def test_update_behaviour_without_weights_with_norm(self):
+        """Test the default behaviour of update without weights and with norm."""
+        hist = Histogram(
+            values=[1, 1, 1, 2, 2],
+            bins=np.array([1, 2, 3]),
+            norm=True,
+        )
+        hist.update(values=np.array([2, 2, 2]))
+        np.testing.assert_array_equal(hist.hist, np.array([0.375, 0.625]))
+        np.testing.assert_array_almost_equal(hist.unc, np.sqrt(np.array([3, 5])) / 8)
+        np.testing.assert_array_almost_equal(
+            hist.band, np.array([0.375, 0.625]) - (np.sqrt(np.array([3, 5])) / 8)
+        )
+
+    def test_update_behaviour_with_weights_no_norm(self):
+        """Test the default behaviour of update with weights and no norm."""
+        hist = Histogram(
+            values=[1, 1, 1, 2, 2],
+            bins=np.array([1, 2, 3]),
+            weights=np.array([2, 3, 1, 1, 10]),
+            norm=False,
+        )
+        hist.update(values=np.array([2, 2, 2]))
+        np.testing.assert_array_equal(hist.hist, np.array([6, 14]))
+        np.testing.assert_array_almost_equal(hist.unc, np.array([3.741657, 10.198039]))
+        np.testing.assert_array_almost_equal(
+            hist.band, np.array([6, 14]) - np.array([3.741657, 10.198039])
+        )
+
+    def test_update_behaviour_with_weights_with_norm(self):
+        """Test the default behaviour of update with weights and with norm."""
+        hist = Histogram(
+            values=[1, 1, 1, 2, 2],
+            bins=np.array([1, 2, 3]),
+            weights=np.array([2, 3, 1, 1, 10]),
+            norm=True,
+        )
+        hist.update(values=np.array([2, 2, 2]))
+        np.testing.assert_array_equal(hist.hist, np.array([0.3, 0.7]))
+        np.testing.assert_array_almost_equal(hist.unc, np.array([0.187083, 0.509902]))
+        np.testing.assert_array_almost_equal(
+            hist.band, np.array([0.3, 0.7]) - np.array([0.187083, 0.509902])
+        )
+
 
 class HistogramIOTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Adding `update()` function to the `Histogram` class. Histograms can now be filled iteratively with this. The first init of the class must be done with the first batch, but afterwards you can simply do `Histogram.update()`.

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
