### PR TITLE
Update `atlas-ftag-tools` to `0.2.16`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update `atlas-ftag-tools` to `0.2.16` [#338](https://github.com/umami-hep/puma/pull/338)
 - Adding Iterative Filling for Histogram Class [#337]
 - Reneable `mypy` [#333](https://github.com/umami-hep/puma/pull/333)
 - Adding `subtract` Method in `VarVsVar` class [#336](https://github.com/umami-hep/puma/pull/336)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-atlas-ftag-tools==0.2.15
+atlas-ftag-tools==0.2.16
 atlasify==0.8.0
 coverage==6.3.1
 h5py>=3.13.0


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update `atlas-ftag-tools` to `0.2.16`

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
