### PR TITLE
Fix binomial_error() masking issue.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Fix binomial_error() masking issue [#360](https://github.com/umami-hep/puma/pull/360)
 - Effective statistics for weighted var vs efficiency plots [#358](https://github.com/umami-hep/puma/pull/358)
 - Fixing Legend Label Issue in Histogram Class [#352](https://github.com/umami-hep/puma/pull/352)
 - Use .item() instead of float() in save_divide [#357](https://github.com/umami-hep/puma/pull/357)

--- a/puma/roc.py
+++ b/puma/roc.py
@@ -199,7 +199,9 @@ class Roc(PlotLineObject):
         if inverse:
             ratio = 1 / ratio
 
-        ratio_err = self.binomial_error(norm=True) * ratio if self.n_test else None
+        ratio_err = (
+            self.binomial_error(norm=True) * ratio[self.non_zero_mask] if self.n_test else None
+        )
         return self.sig_eff, ratio, ratio_err
 
     @property
@@ -706,12 +708,8 @@ class RocPlot(PlotBase):
             if elem.n_test is not None:
                 # if uncertainties are available for roc plotting their uncertainty as
                 # a band around the roc itself
-                rej_band_down = (
-                    elem.bkg_rej[elem.non_zero_mask] - elem.binomial_error()[elem.non_zero_mask]
-                )
-                rej_band_up = (
-                    elem.bkg_rej[elem.non_zero_mask] + elem.binomial_error()[elem.non_zero_mask]
-                )
+                rej_band_down = elem.bkg_rej[elem.non_zero_mask] - elem.binomial_error()
+                rej_band_up = elem.bkg_rej[elem.non_zero_mask] + elem.binomial_error()
                 self.axis_top.fill_between(
                     elem.sig_eff[elem.non_zero_mask],
                     rej_band_down,


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Add the `non_zero_mask` to `ratio` since binomial_error() return an array masked by `non_zero_mask`.
* Avoid applying `non_zero_mask` for a second time in `plot_roc`

Relates to the following issues

* When `non_zero_mask` has some `False` entries, the dimensions or arrays and masks do not match

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
