### PR TITLE
Fix strict MkDocs build warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Fix strict MkDocs documentation build warnings [#364](https://github.com/umami-hep/puma/pull/364)
 - Fix binomial_error() masking issue [#360](https://github.com/umami-hep/puma/pull/360)
 - Effective statistics for weighted var vs efficiency plots [#358](https://github.com/umami-hep/puma/pull/358)
 - Fixing Legend Label Issue in Histogram Class [#352](https://github.com/umami-hep/puma/pull/352)

--- a/docs/dev/docs_development.md
+++ b/docs/dev/docs_development.md
@@ -7,7 +7,6 @@ the corresponding version to the file `docs/source/_static/switcher.json`. The
 corresponding job in the CI will then automatically build the docs for this release and
 add it to the deployment.
 
-![](../assets/version_switcher_update_edit.png)
 
 ## Downloading the artifact of a dev version of the docs
 
@@ -20,12 +19,8 @@ built for _every_ commit, no matter on which branch, and are uploaded as an arti
 This means that you can download the docs as a `.zip` file and then browser the html
 files on your machine.
 
-If you have an open pull request for your changes, you find the artifact like shown
-below (click on the button that is marked with the red circle).
+If you have an open pull request for your changes, open the GitHub Actions run for
+your branch and download the uploaded documentation artifact.
 After downloading, unzip the file and open the `artifact/index.html` file in your browser.
 You should then see the docs that you just downloaded.
-
-![](../assets/artifact_steps_1.png)
-![](../assets/artifact_steps_2.png)
-![](../assets/artifact_steps_3.png)
 

--- a/docs/hlapi/high_level_aux_api.md
+++ b/docs/hlapi/high_level_aux_api.md
@@ -4,7 +4,7 @@ To set up the inputs for the plots, have a look [here](./index.md). In general, 
 for aux task plots, but a separate container with track-level aux task outputs is required to be present in the
 files (by default "tracks"). For now, vertexing and track origin prediction aux tasks are supported.
 
-The following examples use the dummy data which is described [here](./dummy_data.md)
+The following examples use the dummy data which is described [here](../examples/dummy_data.md)
 
 The high level API for aux tasks matches the general high level API in terms of structure. It can be used to
 produce vertexing performance plots.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Contributing:
       - dev/development_guidelines.md
       - dev/docs_development.md
+      - Docker images: dev/docker.md
   - API Reference:
       - Plot Base: api/plot_base.md
       - Histogram: api/histogram.md


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Adds the existing Docker docs page to the MkDocs navigation.
* Removes broken screenshot references from the docs development page.
* Fixes the high-level aux API dummy-data link.
* Adds a changelog entry for the docs build fix.

Relates to the following issues

* Closes #363

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
