### PR TITLE
Update atlas-ftag-tools to v0.3.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update atlas-ftag-tools to v0.3.3 [#368](https://github.com/umami-hep/puma/pull/368)
 - Fix binomial_error() masking issue [#360](https://github.com/umami-hep/puma/pull/360)
 - Effective statistics for weighted var vs efficiency plots [#358](https://github.com/umami-hep/puma/pull/358)
 - Fixing Legend Label Issue in Histogram Class [#352](https://github.com/umami-hep/puma/pull/352)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 [![codecov](https://codecov.io/gh/umami-hep/puma/branch/main/graph/badge.svg)](https://codecov.io/gh/umami-hep/puma)
 ![Testing workflow](https://github.com/umami-hep/puma/actions/workflows/testing.yml/badge.svg)
 ![Linting workflow](https://github.com/umami-hep/puma/actions/workflows/linting.yml/badge.svg)
-![Pages workflow](https://github.com/umami-hep/puma/actions/workflows/pages.yml/badge.svg)
+![Pages workflow](https://github.com/umami-hep/puma/actions/workflows/docs.yml/badge.svg)
 ![Docker build workflow](https://github.com/umami-hep/puma/actions/workflows/docker_build.yml/badge.svg)
 
 The Python package `puma` provides a plotting API for commonly used plots in flavour tagging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 
 dependencies = [
-    "atlas-ftag-tools==0.3.2",
+    "atlas-ftag-tools==0.3.3",
     "atlasify>=0.8.0",
     "h5py>=3.14.0",
     "ipython>=8.37.0",


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update `atlas-ftag-tools` to `v0.3.3`

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
