### PR TITLE
Replace `assert_array_equal` with `assert_array_almost_equal` in tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### [v0.5.3](https://github.com/umami-hep/puma/releases/tag/v0.5.3) (16.06.2026)
 
+- Replace `assert_array_equal` with `assert_array_almost_equal` in tests [#374](https://github.com/umami-hep/puma/pull/374)
 - Adding CLI Flag to Update Reference Plots [#373](https://github.com/umami-hep/puma/pull/373)
 - Allow optional xmin and xmax ticks for PlotBase [#371](https://github.com/umami-hep/puma/pull/371)
 - Fix Issues in with Matplotlib 3.11 [#372](https://github.com/umami-hep/puma/pull/372)

--- a/puma/tests/hlplots/test_results.py
+++ b/puma/tests/hlplots/test_results.py
@@ -129,7 +129,7 @@ class ResultsTestCase(unittest.TestCase):
                     ("TruthLabelID2", "i4"),
                 ]),
             )
-            np.testing.assert_array_equal(
+            np.testing.assert_array_almost_equal(
                 loaded_tagger.labels["TruthLabelID2"],
                 loaded_tagger.labels["HadronConeExclTruthLabelID"] + 1,
             )

--- a/puma/tests/hlplots/test_tagger.py
+++ b/puma/tests/hlplots/test_tagger.py
@@ -96,7 +96,7 @@ class TaggerScoreExtractionTestCase(unittest.TestCase):
         """Test passing data frame."""
         tagger = Tagger("dummy", output_flavours=["ujets", "cjets", "bjets"])
         tagger.extract_tagger_scores(self.df_dummy)
-        np.testing.assert_array_equal(s2u(tagger.scores), self.scores_expected)
+        np.testing.assert_array_almost_equal(s2u(tagger.scores), self.scores_expected)
 
     def test_data_frame_path(self):
         """Test passing data frame path."""
@@ -108,7 +108,7 @@ class TaggerScoreExtractionTestCase(unittest.TestCase):
             tagger.extract_tagger_scores(
                 file_name, key="dummy_tagger", source_type="data_frame_path"
             )
-        np.testing.assert_array_equal(s2u(tagger.scores), self.scores_expected)
+        np.testing.assert_array_almost_equal(s2u(tagger.scores), self.scores_expected)
 
     def test_h5_structured_numpy_path(self):
         """Test passing structured h5 path."""
@@ -119,7 +119,7 @@ class TaggerScoreExtractionTestCase(unittest.TestCase):
                 f_h5.create_dataset(data=self.df_dummy.to_records(), name="dummy_tagger")
 
             tagger.extract_tagger_scores(file_name, key="dummy_tagger", source_type="h5_file")
-        np.testing.assert_array_equal(s2u(tagger.scores), self.scores_expected)
+        np.testing.assert_array_almost_equal(s2u(tagger.scores), self.scores_expected)
 
     def test_structured_array(self):
         """Test passing structured numpy array."""
@@ -129,7 +129,7 @@ class TaggerScoreExtractionTestCase(unittest.TestCase):
             key="dummy_tagger",
             source_type="structured_array",
         )
-        np.testing.assert_array_equal(s2u(tagger.scores), self.scores_expected)
+        np.testing.assert_array_almost_equal(s2u(tagger.scores), self.scores_expected)
 
 
 class TaggerTestCase(unittest.TestCase):
@@ -160,7 +160,7 @@ class TaggerTestCase(unittest.TestCase):
         )
         tagger.scores = self.scores
         discs = tagger.discriminant("bjets")
-        np.testing.assert_array_equal(discs, np.zeros(10))
+        np.testing.assert_array_almost_equal(discs, np.zeros(10))
 
     def test_disc_c_calc(self):
         """Test c-disc calculation."""
@@ -171,7 +171,7 @@ class TaggerTestCase(unittest.TestCase):
         )
         tagger.scores = self.scores
         discs = tagger.discriminant("cjets")
-        np.testing.assert_array_equal(discs, np.zeros(10))
+        np.testing.assert_array_almost_equal(discs, np.zeros(10))
 
     def test_disc_hbb_calc(self):
         """Test hbb-disc calculation."""
@@ -242,19 +242,19 @@ class TaggerProbsTestCase(unittest.TestCase):
         """Test probs method without label_flavour parameter."""
         prob_flavour = "bjets"
         expected_probs = np.ones(10) * 5
-        np.testing.assert_array_equal(self.tagger.probs(prob_flavour), expected_probs)
+        np.testing.assert_array_almost_equal(self.tagger.probs(prob_flavour), expected_probs)
 
     def test_probs_with_label_flavour(self):
         """Test probs method with label_flavour parameter."""
         prob_flavour = "bjets"
         label_flavour = "cjets"
         expected_probs = np.zeros(0)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             self.tagger.probs(prob_flavour, label_flavour), expected_probs
         )
         prob_flavour = "cjets"
         label_flavour = "ujets"
         expected_probs = np.zeros(10)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             self.tagger.probs(prob_flavour, label_flavour), expected_probs
         )

--- a/puma/tests/test_histogram.py
+++ b/puma/tests/test_histogram.py
@@ -172,7 +172,7 @@ class HistogramTestCase(unittest.TestCase):
             norm=False,
         )
         hist.update(values=np.array([2, 2, 2]))
-        np.testing.assert_array_equal(hist.hist, np.array([3, 5]))
+        np.testing.assert_array_almost_equal(hist.hist, np.array([3, 5]))
         np.testing.assert_array_almost_equal(hist.unc, np.sqrt(np.array([3, 5])))
         np.testing.assert_array_almost_equal(
             hist.band, np.array([3, 5]) - np.sqrt(np.array([3, 5]))
@@ -186,7 +186,7 @@ class HistogramTestCase(unittest.TestCase):
             norm=True,
         )
         hist.update(values=np.array([2, 2, 2]))
-        np.testing.assert_array_equal(hist.hist, np.array([0.375, 0.625]))
+        np.testing.assert_array_almost_equal(hist.hist, np.array([0.375, 0.625]))
         np.testing.assert_array_almost_equal(hist.unc, np.sqrt(np.array([3, 5])) / 8)
         np.testing.assert_array_almost_equal(
             hist.band, np.array([0.375, 0.625]) - (np.sqrt(np.array([3, 5])) / 8)
@@ -201,7 +201,7 @@ class HistogramTestCase(unittest.TestCase):
             norm=False,
         )
         hist.update(values=np.array([2, 2, 2]))
-        np.testing.assert_array_equal(hist.hist, np.array([6, 14]))
+        np.testing.assert_array_almost_equal(hist.hist, np.array([6, 14]))
         np.testing.assert_array_almost_equal(hist.unc, np.array([3.741657, 10.198039]))
         np.testing.assert_array_almost_equal(
             hist.band, np.array([6, 14]) - np.array([3.741657, 10.198039])
@@ -216,7 +216,7 @@ class HistogramTestCase(unittest.TestCase):
             norm=True,
         )
         hist.update(values=np.array([2, 2, 2]))
-        np.testing.assert_array_equal(hist.hist, np.array([0.3, 0.7]))
+        np.testing.assert_array_almost_equal(hist.hist, np.array([0.3, 0.7]))
         np.testing.assert_array_almost_equal(hist.unc, np.array([0.187083, 0.509902]))
         np.testing.assert_array_almost_equal(
             hist.band, np.array([0.3, 0.7]) - np.array([0.187083, 0.509902])
@@ -313,7 +313,7 @@ class HistogramIOTestCase(unittest.TestCase):
         self.assertIsNone(decoded["discrete_vals"])
 
         # ndarray round-trip
-        np.testing.assert_array_equal(decoded["hist"], h.hist)
+        np.testing.assert_array_almost_equal(decoded["hist"], h.hist)
 
     # ------------------------------------------------------------------
     # save / load (JSON)
@@ -334,10 +334,10 @@ class HistogramIOTestCase(unittest.TestCase):
             clone = Histogram.load(path)
 
             # numerical arrays survive bit-perfect
-            np.testing.assert_array_equal(h.hist, clone.hist)
-            np.testing.assert_array_equal(h.bin_edges, clone.bin_edges)
-            np.testing.assert_array_equal(h.unc, clone.unc)
-            np.testing.assert_array_equal(h.band, clone.band)
+            np.testing.assert_array_almost_equal(h.hist, clone.hist)
+            np.testing.assert_array_almost_equal(h.bin_edges, clone.bin_edges)
+            np.testing.assert_array_almost_equal(h.unc, clone.unc)
+            np.testing.assert_array_almost_equal(h.band, clone.band)
 
             # metadata
             self.assertEqual(clone.label, h.label)
@@ -636,7 +636,7 @@ class HistogramPlotTestCase(unittest.TestCase):
         )
         hist_plot.draw()
 
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             hist_plot.axis_top.get_xticks(),
             np.array([20, 50, 100, 150, 200, 250]),
         )

--- a/puma/tests/test_plot_base.py
+++ b/puma/tests/test_plot_base.py
@@ -190,7 +190,7 @@ class TestPlotBase(unittest.TestCase):
 
         self.plot_base.apply_xaxis_endpoint_ticks()
 
-        np.testing.assert_array_equal(self.plot_base.axis_top.get_xticks(), ticks)
+        np.testing.assert_array_almost_equal(self.plot_base.axis_top.get_xticks(), ticks)
 
     def test_apply_xaxis_endpoint_ticks(self):
         """Test x-axis endpoint ticks with and without a ratio panel."""
@@ -205,7 +205,7 @@ class TestPlotBase(unittest.TestCase):
                 plot_base.apply_xaxis_endpoint_ticks()
                 axis = plot_base.ratio_axes[-1] if plot_base.ratio_axes else plot_base.axis_top
 
-                np.testing.assert_array_equal(
+                np.testing.assert_array_almost_equal(
                     axis.get_xticks(),
                     np.array([20, 50, 100, 150, 200, 250]),
                 )

--- a/puma/tests/test_roc.py
+++ b/puma/tests/test_roc.py
@@ -177,7 +177,7 @@ class RocIOTestCase(unittest.TestCase):
         self.assertIsNone(decoded["key"])
 
         # ndarray round-trip
-        np.testing.assert_array_equal(decoded["sig_eff"], h.sig_eff)
+        np.testing.assert_array_almost_equal(decoded["sig_eff"], h.sig_eff)
 
     # ------------------------------------------------------------------
     # save / load (JSON)
@@ -198,8 +198,8 @@ class RocIOTestCase(unittest.TestCase):
             clone = Roc.load(path)
 
             # numerical arrays survive bit-perfect
-            np.testing.assert_array_equal(h.sig_eff, clone.sig_eff)
-            np.testing.assert_array_equal(h.bkg_rej, clone.bkg_rej)
+            np.testing.assert_array_almost_equal(h.sig_eff, clone.sig_eff)
+            np.testing.assert_array_almost_equal(h.bkg_rej, clone.bkg_rej)
 
             # metadata
             self.assertEqual(clone.label, h.label)

--- a/puma/tests/test_var_vs_eff.py
+++ b/puma/tests/test_var_vs_eff.py
@@ -730,7 +730,7 @@ class VarVsEffIOTestCase(unittest.TestCase):
         decoded = VarVsEff.decode(encoded)
 
         # The numerical data must match exactly
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             decoded["results"]["normal"]["sig_eff"]["y_value"],
             v.results["normal"]["sig_eff"]["y_value"],
         )
@@ -763,7 +763,7 @@ class VarVsEffIOTestCase(unittest.TestCase):
             self.assertEqual(clone, v)
 
             # Check one representative array field
-            np.testing.assert_array_equal(
+            np.testing.assert_array_almost_equal(
                 clone.results["normal"]["bkg_eff"]["y_error"],
                 v.results["normal"]["bkg_eff"]["y_error"],
             )
@@ -917,7 +917,7 @@ class VarVsEffOutputTestCase(unittest.TestCase):
                 plot.draw()
                 axis = plot.ratio_axes[-1] if plot.ratio_axes else plot.axis_top
 
-                np.testing.assert_array_equal(
+                np.testing.assert_array_almost_equal(
                     axis.get_xticks(),
                     np.array([20, 50, 100, 150, 200, 250]),
                 )

--- a/puma/tests/test_var_vs_var.py
+++ b/puma/tests/test_var_vs_var.py
@@ -157,7 +157,7 @@ class VarVsVarIOTestCase(unittest.TestCase):
 
         # ── decoding restores original Python objects ────────────────────
         decoded = VarVsVar.decode(encoded)
-        np.testing.assert_array_equal(decoded["y_var_std"], v.y_var_std)
+        np.testing.assert_array_almost_equal(decoded["y_var_std"], v.y_var_std)
         self.assertEqual(decoded["colour"], v.colour)  # tuple restored
         self.assertTrue(decoded["fill"])
 
@@ -180,10 +180,10 @@ class VarVsVarIOTestCase(unittest.TestCase):
             clone = VarVsVar.load(path)
 
             # numerical arrays survive bit-perfect
-            np.testing.assert_array_equal(v.x_var, clone.x_var)
-            np.testing.assert_array_equal(v.y_var_mean, clone.y_var_mean)
-            np.testing.assert_array_equal(v.y_var_std, clone.y_var_std)
-            np.testing.assert_array_equal(v.x_var_widths, clone.x_var_widths)
+            np.testing.assert_array_almost_equal(v.x_var, clone.x_var)
+            np.testing.assert_array_almost_equal(v.y_var_mean, clone.y_var_mean)
+            np.testing.assert_array_almost_equal(v.y_var_std, clone.y_var_std)
+            np.testing.assert_array_almost_equal(v.x_var_widths, clone.x_var_widths)
 
             # metadata
             self.assertEqual(clone.key, v.key)

--- a/puma/tests/utils/test_mass.py
+++ b/puma/tests/utils/test_mass.py
@@ -25,7 +25,7 @@ class VertexMassTestCase(unittest.TestCase):
         vtx_idx = np.zeros((5, 10))
         vtx_masses = calculate_vertex_mass(track_pt, track_eta, track_phi, vtx_idx)
         expected_shape = (5, 10)
-        np.testing.assert_array_equal(vtx_masses.shape, expected_shape)
+        np.testing.assert_array_almost_equal(vtx_masses.shape, expected_shape)
 
     def test_single_track_only(self):
         """Check case where only single track vertices exist."""
@@ -35,7 +35,7 @@ class VertexMassTestCase(unittest.TestCase):
         vtx_idx = np.array([[0, 1, 2, 3, 4]])
         vtx_masses = calculate_vertex_mass(track_pt, track_eta, track_phi, vtx_idx, particle_mass=2)
         expected_result = np.array([[2, 2, 2, 2, 2]])
-        np.testing.assert_array_equal(vtx_masses, expected_result)
+        np.testing.assert_array_almost_equal(vtx_masses, expected_result)
 
     def test_multiple_vertices(self):
         """Check more complicated case with two vertices."""
@@ -66,4 +66,4 @@ class VertexMassTestCase(unittest.TestCase):
             track_pt, track_eta, track_phi, vtx_idx, particle_mass=0.13957
         )
         expected_result = np.array([[vtx_mass_1, vtx_mass_1, vtx_mass_2, vtx_mass_2, vtx_mass_2]])
-        np.testing.assert_array_equal(vtx_masses, expected_result)
+        np.testing.assert_array_almost_equal(vtx_masses, expected_result)

--- a/puma/tests/utils/test_vertexing.py
+++ b/puma/tests/utils/test_vertexing.py
@@ -28,7 +28,7 @@ class CleanIndicesTestCase(unittest.TestCase):
         condition = np.array([[True, False, False, False, True]])
         updated_ids = clean_indices(vertex_ids, condition, mode="remove")
         expected_result = np.array([[-99, 1, 1, 2, -99]])
-        np.testing.assert_array_equal(updated_ids, expected_result)
+        np.testing.assert_array_almost_equal(updated_ids, expected_result)
 
     def test_merge(self):
         """Check case where indices are merged."""
@@ -36,7 +36,7 @@ class CleanIndicesTestCase(unittest.TestCase):
         condition = np.array([[True, False, False, True, False]])
         updated_ids = clean_indices(vertex_ids, condition, mode="merge")
         expected_result = np.array([[3, 1, 1, 3, 1]])
-        np.testing.assert_array_equal(updated_ids, expected_result)
+        np.testing.assert_array_almost_equal(updated_ids, expected_result)
 
     def test_invalid_mode(self):
         """Check case where an invalid mode is provided."""
@@ -60,7 +60,7 @@ class BuildVerticesTestCase(unittest.TestCase):
         indices = np.array([0, 1, 2, 2, 3])
         expected_result = np.array([[False, False, True, True, False]])
         vertices = build_vertices(indices)
-        np.testing.assert_array_equal(vertices, expected_result)
+        np.testing.assert_array_almost_equal(vertices, expected_result)
 
     def test_complex_case(self):
         """Check complex case with multiple vertices."""
@@ -71,7 +71,7 @@ class BuildVerticesTestCase(unittest.TestCase):
             [False, False, False, False, True, False, True, True, False, False],
         ])
         vertices = build_vertices(indices)
-        np.testing.assert_array_equal(vertices, expected_result)
+        np.testing.assert_array_almost_equal(vertices, expected_result)
 
     def test_arbitrary_indices(self):
         """Check case where vertex indices are arbitrary."""
@@ -81,14 +81,14 @@ class BuildVerticesTestCase(unittest.TestCase):
             [False, False, False, True, True],
         ])
         vertices = build_vertices(indices)
-        np.testing.assert_array_equal(vertices, expected_result)
+        np.testing.assert_array_almost_equal(vertices, expected_result)
 
     def test_ignore_negatives(self):
         """Check case where negative indices are present."""
         indices = np.array([0, -2, 0, -2, -1, -1, -1])
         expected_result = np.array([[True, False, True, False, False, False, False]])
         vertices = build_vertices(indices)
-        np.testing.assert_array_equal(vertices, expected_result)
+        np.testing.assert_array_almost_equal(vertices, expected_result)
 
 
 class AssociateVerticesTestCase(unittest.TestCase):
@@ -105,8 +105,8 @@ class AssociateVerticesTestCase(unittest.TestCase):
         expected_assoc = np.array([[False]])
         expected_common = np.array([[0]])
         assoc, common = associate_vertices(vertices1, vertices2, 0.0, 0.0)
-        np.testing.assert_array_equal(assoc, expected_assoc)
-        np.testing.assert_array_equal(common, expected_common)
+        np.testing.assert_array_almost_equal(assoc, expected_assoc)
+        np.testing.assert_array_almost_equal(common, expected_common)
 
     def test_association_condition1(self):
         """Check case where associations are made based on most common tracks."""
@@ -123,8 +123,8 @@ class AssociateVerticesTestCase(unittest.TestCase):
         ])
         expected_common = np.array([[2], [1]])
         assoc, common = associate_vertices(vertices1, vertices2, 0.0, 0.0)
-        np.testing.assert_array_equal(assoc, expected_assoc)
-        np.testing.assert_array_equal(common, expected_common)
+        np.testing.assert_array_almost_equal(assoc, expected_assoc)
+        np.testing.assert_array_almost_equal(common, expected_common)
 
     def test_association_condition2(self):
         """Check case where associations are made based on
@@ -143,8 +143,8 @@ class AssociateVerticesTestCase(unittest.TestCase):
         ])
         expected_common = np.array([[2], [2]])
         assoc, common = associate_vertices(vertices1, vertices2, 0.0, 0.0)
-        np.testing.assert_array_equal(assoc, expected_assoc)
-        np.testing.assert_array_equal(common, expected_common)
+        np.testing.assert_array_almost_equal(assoc, expected_assoc)
+        np.testing.assert_array_almost_equal(common, expected_common)
 
     def test_association_condition3(self):
         """Check case where associations are made based on
@@ -160,8 +160,8 @@ class AssociateVerticesTestCase(unittest.TestCase):
         expected_assoc = np.array([[True, False]])
         expected_common = np.array([[2, 2]])
         assoc, common = associate_vertices(vertices1, vertices2, 0.0, 0.0)
-        np.testing.assert_array_equal(assoc, expected_assoc)
-        np.testing.assert_array_equal(common, expected_common)
+        np.testing.assert_array_almost_equal(assoc, expected_assoc)
+        np.testing.assert_array_almost_equal(common, expected_common)
 
     def test_association_condition4(self):
         """Check case where associations are made based on
@@ -180,8 +180,8 @@ class AssociateVerticesTestCase(unittest.TestCase):
         ])
         expected_common = np.array([[2], [2]])
         assoc, common = associate_vertices(vertices1, vertices2, 0.0, 0.0)
-        np.testing.assert_array_equal(assoc, expected_assoc)
-        np.testing.assert_array_equal(common, expected_common)
+        np.testing.assert_array_almost_equal(assoc, expected_assoc)
+        np.testing.assert_array_almost_equal(common, expected_common)
 
     def test_full_associations(self):
         """Check case where associations are a perfect match."""
@@ -194,8 +194,8 @@ class AssociateVerticesTestCase(unittest.TestCase):
         expected_assoc = np.array([[True]])
         expected_common = np.array([[2]])
         assoc, common = associate_vertices(vertices1, vertices2, 0.0, 0.0)
-        np.testing.assert_array_equal(assoc, expected_assoc)
-        np.testing.assert_array_equal(common, expected_common)
+        np.testing.assert_array_almost_equal(assoc, expected_assoc)
+        np.testing.assert_array_almost_equal(common, expected_common)
 
 
 class CalculateVertexMetricsTestCase(unittest.TestCase):
@@ -212,12 +212,12 @@ class CalculateVertexMetricsTestCase(unittest.TestCase):
             eff_req=0.0,
             purity_req=0.0,
         )
-        np.testing.assert_array_equal(metrics["n_match"], [0])
-        np.testing.assert_array_equal(metrics["n_test"], [0])
-        np.testing.assert_array_equal(metrics["n_ref"], [0])
-        np.testing.assert_array_equal(metrics["track_overlap"], [[-1, -1]])
-        np.testing.assert_array_equal(metrics["test_vertex_size"], [[-1, -1]])
-        np.testing.assert_array_equal(metrics["ref_vertex_size"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["n_match"], [0])
+        np.testing.assert_array_almost_equal(metrics["n_test"], [0])
+        np.testing.assert_array_almost_equal(metrics["n_ref"], [0])
+        np.testing.assert_array_almost_equal(metrics["track_overlap"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["test_vertex_size"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["ref_vertex_size"], [[-1, -1]])
 
     def test_no_reco_vertices(self):
         """Check case where there are no reco vertices."""
@@ -230,12 +230,12 @@ class CalculateVertexMetricsTestCase(unittest.TestCase):
             eff_req=0.0,
             purity_req=0.0,
         )
-        np.testing.assert_array_equal(metrics["n_match"], [0])
-        np.testing.assert_array_equal(metrics["n_test"], [0])
-        np.testing.assert_array_equal(metrics["n_ref"], [1])
-        np.testing.assert_array_equal(metrics["track_overlap"], [[-1, -1]])
-        np.testing.assert_array_equal(metrics["test_vertex_size"], [[-1, -1]])
-        np.testing.assert_array_equal(metrics["ref_vertex_size"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["n_match"], [0])
+        np.testing.assert_array_almost_equal(metrics["n_test"], [0])
+        np.testing.assert_array_almost_equal(metrics["n_ref"], [1])
+        np.testing.assert_array_almost_equal(metrics["track_overlap"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["test_vertex_size"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["ref_vertex_size"], [[-1, -1]])
 
     def test_no_truth_vertices(self):
         """Check case where there are no truth vertices."""
@@ -248,12 +248,12 @@ class CalculateVertexMetricsTestCase(unittest.TestCase):
             eff_req=0.0,
             purity_req=0.0,
         )
-        np.testing.assert_array_equal(metrics["n_match"], [0])
-        np.testing.assert_array_equal(metrics["n_test"], [1])
-        np.testing.assert_array_equal(metrics["n_ref"], [0])
-        np.testing.assert_array_equal(metrics["track_overlap"], [[-1, -1]])
-        np.testing.assert_array_equal(metrics["test_vertex_size"], [[-1, -1]])
-        np.testing.assert_array_equal(metrics["ref_vertex_size"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["n_match"], [0])
+        np.testing.assert_array_almost_equal(metrics["n_test"], [1])
+        np.testing.assert_array_almost_equal(metrics["n_ref"], [0])
+        np.testing.assert_array_almost_equal(metrics["track_overlap"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["test_vertex_size"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["ref_vertex_size"], [[-1, -1]])
 
     def test_no_match(self):
         """Check case where there are no vertex matches."""
@@ -266,12 +266,12 @@ class CalculateVertexMetricsTestCase(unittest.TestCase):
             eff_req=0.0,
             purity_req=0.0,
         )
-        np.testing.assert_array_equal(metrics["n_match"], [0])
-        np.testing.assert_array_equal(metrics["n_test"], [1])
-        np.testing.assert_array_equal(metrics["n_ref"], [1])
-        np.testing.assert_array_equal(metrics["track_overlap"], [[-1, -1]])
-        np.testing.assert_array_equal(metrics["test_vertex_size"], [[-1, -1]])
-        np.testing.assert_array_equal(metrics["ref_vertex_size"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["n_match"], [0])
+        np.testing.assert_array_almost_equal(metrics["n_test"], [1])
+        np.testing.assert_array_almost_equal(metrics["n_ref"], [1])
+        np.testing.assert_array_almost_equal(metrics["track_overlap"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["test_vertex_size"], [[-1, -1]])
+        np.testing.assert_array_almost_equal(metrics["ref_vertex_size"], [[-1, -1]])
 
     def test_one_match(self):
         """Check case where there is one vertex match."""
@@ -284,12 +284,12 @@ class CalculateVertexMetricsTestCase(unittest.TestCase):
             eff_req=0.0,
             purity_req=0.0,
         )
-        np.testing.assert_array_equal(metrics["n_match"], [1])
-        np.testing.assert_array_equal(metrics["n_test"], [2])
-        np.testing.assert_array_equal(metrics["n_ref"], [1])
-        np.testing.assert_array_equal(metrics["track_overlap"], [[2, -1]])
-        np.testing.assert_array_equal(metrics["test_vertex_size"], [[2, -1]])
-        np.testing.assert_array_equal(metrics["ref_vertex_size"], [[3, -1]])
+        np.testing.assert_array_almost_equal(metrics["n_match"], [1])
+        np.testing.assert_array_almost_equal(metrics["n_test"], [2])
+        np.testing.assert_array_almost_equal(metrics["n_ref"], [1])
+        np.testing.assert_array_almost_equal(metrics["track_overlap"], [[2, -1]])
+        np.testing.assert_array_almost_equal(metrics["test_vertex_size"], [[2, -1]])
+        np.testing.assert_array_almost_equal(metrics["ref_vertex_size"], [[3, -1]])
 
     def test_mult_matches(self):
         """Check case where there are multiple vertex matches."""
@@ -302,12 +302,12 @@ class CalculateVertexMetricsTestCase(unittest.TestCase):
             eff_req=0.0,
             purity_req=0.0,
         )
-        np.testing.assert_array_equal(metrics["n_match"], [3])
-        np.testing.assert_array_equal(metrics["n_test"], [3])
-        np.testing.assert_array_equal(metrics["n_ref"], [4])
-        np.testing.assert_array_equal(metrics["track_overlap"], [[2, 2, 2]])
-        np.testing.assert_array_equal(metrics["test_vertex_size"], [[3, 3, 2]])
-        np.testing.assert_array_equal(metrics["ref_vertex_size"], [[3, 2, 2]])
+        np.testing.assert_array_almost_equal(metrics["n_match"], [3])
+        np.testing.assert_array_almost_equal(metrics["n_test"], [3])
+        np.testing.assert_array_almost_equal(metrics["n_ref"], [4])
+        np.testing.assert_array_almost_equal(metrics["track_overlap"], [[2, 2, 2]])
+        np.testing.assert_array_almost_equal(metrics["test_vertex_size"], [[3, 3, 2]])
+        np.testing.assert_array_almost_equal(metrics["ref_vertex_size"], [[3, 2, 2]])
 
     def test_eff_req(self):
         """Check case where efficiency requirement is not met."""
@@ -320,12 +320,12 @@ class CalculateVertexMetricsTestCase(unittest.TestCase):
             eff_req=0.7,
             purity_req=0.0,
         )
-        np.testing.assert_array_equal(metrics["n_match"], [1])
-        np.testing.assert_array_equal(metrics["n_test"], [2])
-        np.testing.assert_array_equal(metrics["n_ref"], [2])
-        np.testing.assert_array_equal(metrics["track_overlap"], [[2, -1]])
-        np.testing.assert_array_equal(metrics["test_vertex_size"], [[2, -1]])
-        np.testing.assert_array_equal(metrics["ref_vertex_size"], [[2, -1]])
+        np.testing.assert_array_almost_equal(metrics["n_match"], [1])
+        np.testing.assert_array_almost_equal(metrics["n_test"], [2])
+        np.testing.assert_array_almost_equal(metrics["n_ref"], [2])
+        np.testing.assert_array_almost_equal(metrics["track_overlap"], [[2, -1]])
+        np.testing.assert_array_almost_equal(metrics["test_vertex_size"], [[2, -1]])
+        np.testing.assert_array_almost_equal(metrics["ref_vertex_size"], [[2, -1]])
 
     def test_purity_req(self):
         """Check case where purity requirement is not met."""
@@ -338,12 +338,12 @@ class CalculateVertexMetricsTestCase(unittest.TestCase):
             eff_req=0.0,
             purity_req=0.7,
         )
-        np.testing.assert_array_equal(metrics["n_match"], [1])
-        np.testing.assert_array_equal(metrics["n_test"], [2])
-        np.testing.assert_array_equal(metrics["n_ref"], [2])
-        np.testing.assert_array_equal(metrics["track_overlap"], [[2, -1]])
-        np.testing.assert_array_equal(metrics["test_vertex_size"], [[2, -1]])
-        np.testing.assert_array_equal(metrics["ref_vertex_size"], [[2, -1]])
+        np.testing.assert_array_almost_equal(metrics["n_match"], [1])
+        np.testing.assert_array_almost_equal(metrics["n_test"], [2])
+        np.testing.assert_array_almost_equal(metrics["n_ref"], [2])
+        np.testing.assert_array_almost_equal(metrics["track_overlap"], [[2, -1]])
+        np.testing.assert_array_almost_equal(metrics["test_vertex_size"], [[2, -1]])
+        np.testing.assert_array_almost_equal(metrics["ref_vertex_size"], [[2, -1]])
 
 
 class CleanTruthVerticesTestCase(unittest.TestCase):
@@ -355,7 +355,7 @@ class CleanTruthVerticesTestCase(unittest.TestCase):
         trk_origin = np.array([2, 0, 2, 1, 1, 2, 2, 0, 4, 4, 3, 3])
         cleaned_indices = clean_truth_vertices(vtx_indices, trk_origin)
         expected_result = np.array([-99, -99, -99, -99, -99, -99, -99, -99, -99, -99, 3, 3])
-        np.testing.assert_array_equal(cleaned_indices, expected_result)
+        np.testing.assert_array_almost_equal(cleaned_indices, expected_result)
 
     def test_incl_hf_vtx_merging(self):
         """Check case in inclusive vertexing where HF vertices are merged."""
@@ -363,7 +363,7 @@ class CleanTruthVerticesTestCase(unittest.TestCase):
         trk_origin = np.array([2, 2, 3, 4, 3, 4, 4, 4])
         cleaned_indices = clean_truth_vertices(vtx_indices, trk_origin, incl_vertexing=True)
         expected_result = np.array([-99, -99, 3, 3, 3, 3, 3, 3])
-        np.testing.assert_array_equal(cleaned_indices, expected_result)
+        np.testing.assert_array_almost_equal(cleaned_indices, expected_result)
 
 
 class CleanRecoVerticesTestCase(unittest.TestCase):
@@ -375,7 +375,7 @@ class CleanRecoVerticesTestCase(unittest.TestCase):
         trk_origin = np.array([2, 4, 2, 2, 2, 2, 3, 3, 4])
         cleaned_indices = clean_reco_vertices(vtx_indices, trk_origin)
         expected_result = np.array([-99, -99, -99, -99, -99, 1, 1, 1, 1])
-        np.testing.assert_array_equal(cleaned_indices, expected_result)
+        np.testing.assert_array_almost_equal(cleaned_indices, expected_result)
 
     def test_non_hf_vtx_removal(self):
         """Check case where vertices without HF track are removed."""
@@ -383,7 +383,7 @@ class CleanRecoVerticesTestCase(unittest.TestCase):
         trk_origin = np.array([2, 0, 2, 1, 1, 2, 2, 0, 4, 4, 3, 3])
         cleaned_indices = clean_reco_vertices(vtx_indices, trk_origin)
         expected_result = np.array([-99, -99, -99, -99, -99, -99, 2, -99, 2, 2, 3, 3])
-        np.testing.assert_array_equal(cleaned_indices, expected_result)
+        np.testing.assert_array_almost_equal(cleaned_indices, expected_result)
 
     def test_incl_track_merging_hf(self):
         """Check case in incl vertexing w track origin prediction where HF vertices are merged."""
@@ -391,11 +391,11 @@ class CleanRecoVerticesTestCase(unittest.TestCase):
         trk_origin = np.array([2, 2, 3, 3, 3, 5, 7, 5, 7, 7])
         cleaned_indices = clean_reco_vertices(vtx_indices, trk_origin, incl_vertexing=True)
         expected_result = np.array([-99, -99, 3, 3, 3, 3, 3, 3, -99, -99])
-        np.testing.assert_array_equal(cleaned_indices, expected_result)
+        np.testing.assert_array_almost_equal(cleaned_indices, expected_result)
 
     def test_incl_track_merging_all(self):
         """Check case in incl vertexing w/o trk_origin prediction where all vertices are merged."""
         vtx_indices = np.array([-2, -2, 0, 1, -2, 1, 1, 0])
         cleaned_indices = clean_reco_vertices(vtx_indices, incl_vertexing=True)
         expected_result = np.array([-2, -2, 2, 2, -2, 2, 2, 2])
-        np.testing.assert_array_equal(cleaned_indices, expected_result)
+        np.testing.assert_array_almost_equal(cleaned_indices, expected_result)


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* In the tests, replace `np.testing.assert_array_equal` with `np.testing.assert_array_almost_equal` to avoid floating point issues in comparisons.

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/puma/)
