### PR TITLE
Update atlas-ftag-tools to v0.3.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Update atlas-ftag-tools to v0.3.5 [#375](https://github.com/umami-hep/puma/pull/375)
+
 ### [v0.5.3](https://github.com/umami-hep/puma/releases/tag/v0.5.3) (16.06.2026)
 
 - Replace `assert_array_equal` with `assert_array_almost_equal` in tests [#374](https://github.com/umami-hep/puma/pull/374)

--- a/puma/hlplots/aux_results.py
+++ b/puma/hlplots/aux_results.py
@@ -160,9 +160,20 @@ class AuxResults:
 
         # load data
         reader = H5Reader(file_path, precision="full", shuffle=False)
-        data = reader.load({key: var_list}, num_jets)[key]
-        aux_reader = H5Reader(file_path, precision="full", jets_name=aux_key, shuffle=False)
-        aux_data = aux_reader.load({aux_key: aux_var_list}, num_jets)[aux_key]
+        data = reader.load(
+            variables={key: var_list},
+            num_global_objects=num_jets,
+        )[key]
+        aux_reader = H5Reader(
+            fname=file_path,
+            precision="full",
+            global_objects_name=aux_key,
+            shuffle=False,
+        )
+        aux_data = aux_reader.load(
+            variables={aux_key: aux_var_list},
+            num_global_objects=num_jets,
+        )[aux_key]
 
         # check for nan values
         data = check_nan(data)

--- a/puma/hlplots/n_track_origin.py
+++ b/puma/hlplots/n_track_origin.py
@@ -200,7 +200,7 @@ def n_tracks_per_origin(
                     jets_name: [jet_pt_variable, flavour_label_variable],
                     tracks_name: [track_truth_variable],
                 },
-                num_jets=file_value.get("n_jets", None),
+                num_global_objects=file_value.get("n_jets", None),
                 cuts=kinematic_cuts + flavour.cuts,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 
 dependencies = [
-    "atlas-ftag-tools==0.3.3",
+    "atlas-ftag-tools==0.3.5",
     "atlasify>=0.8.0",
     "h5py>=3.14.0",
     "ipython>=8.37.0",


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update `atlas-ftag-tools` to `v0.3.5`

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/puma/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/puma/)
